### PR TITLE
Diagnostics, privacy-safe logging, attestor 5.1.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,109 +4,666 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Reclaim Protocol Browser Extension SDK - enables websites and browser extensions to trigger Reclaim zero-knowledge proof verification flows. The SDK handles content ↔ background communication, opens provider tabs, generates proofs via an offscreen document (WebAssembly), and emits completion events.
+`@reclaimprotocol/browser-extension-sdk` — lets a website or a browser extension trigger a Reclaim
+zero-knowledge-proof verification flow. The SDK opens the provider's site in a managed tab, intercepts
+the page's network traffic, builds a claim from a matching request, generates a ZK proof in an offscreen
+document (WASM), and submits/emits the proof.
 
-**Chrome Manifest V3 compatible.**
+This is a **library**, not a shippable extension. It publishes prebuilt bundles that a consumer
+extension copies into its own `public/` folder — consumers cannot re-bundle them. Chrome MV3 primary,
+MV2/Firefox variants also emitted.
 
-## Build Commands
+## Commands
 
 ```bash
-# Build for production (outputs to build/)
-npm run build
-
-# Format code with Prettier
-npm run format
-
-# Copy SDK assets to consumer extension's public folder
-npm run reclaim-extension-setup
+npm run build     # prettier --write . (prebuild), then webpack over all 3 configs → build/ + zip/
+npm test          # node:test over src/**/*.test.js
+npm run format    # prettier --write .
 ```
 
-Note: There is no test command configured (`npm test` exits with error). The `prebuild` script runs Prettier automatically.
+- [example-provider.test.js](src/utils/claim-creator/example-provider.test.js) is the closest thing to
+  an end-to-end check: it takes the three `requestData` entries of the **published** `example` provider
+  and walks a real request/response pair through `describeRequestMatch` → `extractParamsFromResponse`,
+  asserting the parameter values a real session actually produced (2b46b57c39). It covers all three of
+  that provider's redaction styles (`xPath+regex`, `jsonPath+regex`, `jsonPath+regex+hash`). It does
+  **not** cover proof generation — that needs WASM, the ZK circuits and a live attestor socket. Update
+  its fixtures if the provider is republished.
+- Tests run on Node's built-in runner — no Jest. Source files are ESM `.js` in a package with no
+  `"type": "module"` (webpack.config.js is CJS, so it can't be added), so Node falls back to module-syntax
+  detection; `--disable-warning=MODULE_TYPELESS_PACKAGE_JSON` in the `test` script silences the resulting
+  noise. **Relative imports in `src/utils/claim-creator/` need explicit `.js` extensions** — webpack
+  resolves extensionless paths, Node's ESM loader does not.
+- The test glob is quoted so Node expands it, not the shell. Don't pass a bare directory to `node --test`:
+  it runs _every_ file in it, including non-tests like `src/utils/polyfill-test.js`.
+- **`reclaim-extension-setup` is not a script in this repo.** It's a line consumers add to _their_
+  `package.json` pointing at `build/scripts/install-assets.js`; see
+  [examples/basic-extension/package.json](examples/basic-extension/package.json).
+- [webpack-build-utils/build.js](webpack-build-utils/build.js) sets `config.mode` and appends
+  `ZipPlugin` on the **array** exported by `webpack.config.js`, so neither actually reaches the three
+  configs. Effective mode comes from `process.env.NODE_ENV`, which `build.js` sets to `production`.
+
+### Verifying a change end to end
+
+There is no dev server for the SDK itself. Both examples depend on it via `file:../../`:
+
+```bash
+npm run build                          # rebuild SDK bundles
+cd examples/basic-extension
+npm install && npm run build           # runs install-assets, then vite build → dist/
+                                       # then load dist/ as an unpacked extension in Chrome
+```
+
+`examples/basic-extension` covers the extension-context path; `examples/web-app` covers the web-page
+path (needs `extensionID`).
 
 ## Architecture
 
-The SDK follows a multi-context browser extension architecture with three main execution contexts:
+### Contexts and entry points
 
-### Entry Points
+| Context               | Entry                                                        | Notes                                             |
+| --------------------- | ------------------------------------------------------------ | ------------------------------------------------- |
+| Consumer page / popup | [src/ReclaimExtensionSDK.js](src/ReclaimExtensionSDK.js)     | Public API surface                                |
+| Service worker        | [src/background/background.js](src/background/background.js) | `initBackground()` returns `ctx`                  |
+| Content script        | [src/content/content.js](src/content/content.js)             | Runs in every tab, activates only in managed tabs |
+| Page (MAIN world)     | [src/interceptor/](src/interceptor/)                         | `fetch`/`XHR` patching + `window.Reclaim` API     |
+| Offscreen document    | [src/offscreen/offscreen.js](src/offscreen/offscreen.js)     | attestor-core WASM + WebSocket                    |
 
-1. **ReclaimExtensionSDK** (`src/ReclaimExtensionSDK.js`) - Main SDK class exported for consumers
-   - `reclaimExtensionSDK.init(appId, appSecret, providerId, options)` - Primary API
-   - `reclaimExtensionSDK.initializeBackground()` - Must be called in consumer's service worker
-   - `reclaimExtensionSDK.fromJsonString(json, options)` - Create from server-generated config
-   - Works in both extension context (popup/panel) and web page context (requires `extensionID`)
+The SDK detects its own mode in the constructor: `chrome-extension:` protocol → `"extension"` (talks to
+background via `chrome.runtime.sendMessage`), otherwise `"web"` (talks to the content script via
+`window.postMessage`, and `extensionID` becomes mandatory).
 
-2. **Background Service** (`src/background/`) - Chrome service worker context
-   - `background.js` - Main orchestrator, context initialization
-   - `messageRouter.js` - Central message dispatcher
-   - `sessionManager.js` - Verification session lifecycle
-   - `proofQueue.js` - Sequential proof generation queue
-   - `tabManager.js` - Browser tab management
-   - `cookieUtils.js` - Cookie extraction for auth
-
-3. **Content Script** (`src/content/`) - Injected into web pages
-   - `content.js` - Bridge between web pages/SDK and background
-   - Handles network interception coordination
-   - Manages verification popup UI
-
-4. **Offscreen Document** (`src/offscreen/`) - Isolated WebAssembly execution
-   - Handles zero-knowledge proof generation via `@reclaimprotocol/attestor-core`
-   - Private key generation
-   - WebSocket connections to Reclaim infrastructure
-
-5. **Network Interceptor** (`src/interceptor/`) - Request/response capture
-   - `network-interceptor.js` - Captures network traffic
-   - `injection-scripts.js` - Page injection utilities
-
-### Message Flow
+### The verification pipeline
 
 ```
-Web Page/SDK ↔ Content Script ↔ Background Service ↔ Offscreen Document
-                    ↓                                        ↓
-           Network Interceptor                      Attestor Core (WASM)
+SDK.init()          → POST /api/sdk/init/session/  (ethers Wallet signs {providerId,timestamp}) → sessionId
+startVerification() → START_VERIFICATION → sessionManager.startVerification
+                        ├─ fetchProviderData(providerId) from api.reclaimprotocol.org
+                        ├─ optional CSP-stripping DNR rule (cspRuleManager)
+                        └─ chrome.tabs.create(loginUrl) → tab added to ctx.managedTabs
+content script (managed tab) → injects network-interceptor + injection-scripts into MAIN world
+interceptor → INTERCEPTED_REQUEST_AND_RESPONSE → content.filterInterceptedRequests()
+                        (polls every NETWORK_FILTERING_INTERVAL_MS against providerData.requestData)
+match → FILTERED_REQUEST_FOUND → ctx.processFilteredRequest (background.js)
+                        ├─ attach cookies (cookieUtils) + pageOrigin
+                        ├─ createClaimObject (claim-creator)
+                        └─ proofQueue.addToProofGenerationQueue
+proofQueue → generateProof → offscreen document → attestor-core → proof
+all requestHashes satisfied → sessionManager.submitProofs → callbackUrl / PROOF_SUBMITTED
 ```
 
-### Build Output Structure
+Non-obvious properties of this pipeline:
 
-The webpack config produces three separate builds:
+- **The background is single-session.** `ctx.activeSessionId` rejects a second concurrent
+  `START_VERIFICATION`. The SDK therefore serializes calls through a module-level
+  `_verificationQueue` in `ReclaimExtensionSDK.js`. Both guards exist; don't remove one assuming the
+  other covers it.
+- **Shared-context (`ctx`) pattern.** `initBackground()` builds one plain object holding all session
+  state _and_ injected dependencies (`fetchProviderData`, `generateProof`, `MESSAGE_ACTIONS`,
+  `loggingHub`, …), then binds module functions onto it (`ctx.failSession`, `ctx.submitProofs`). Every
+  background module is a set of free functions taking `ctx` first — there are no classes and no module
+  scope state. New session state belongs in the `ctx` literal _and_ in the reset block at the top of
+  `sessionManager.startVerification`, which is what clears state between sessions.
+- **Every terminal path must emit a terminal event.** The SDK's `startVerification()` returns a Promise
+  resolved only by `completed`/`error`. Anything that ends a session (tab closed, provider error,
+  concurrency rejection, `startVerification` throwing) has to route through `failSession` or send
+  `PROOF_GENERATION_FAILED`, or the consumer's Promise hangs forever. `messageRouter` restores
+  `ctx.sessionId` before calling `failSession` for exactly this reason — the SDK drops events whose
+  `sessionId` doesn't match.
+- **Timers.** `SessionTimerManager` starts only on the _first_ intercepted request
+  (`ctx.firstRequestReceived`) and fails the session if no proof lands within
+  `SESSION_TIMER_DURATION_MS`. It is _paused_ across proof generation, so the 30 s window never kills a
+  proof. All tunables live in [src/utils/constants/config.js](src/utils/constants/config.js) — put new
+  timeouts there, not inline.
+- **The two proof timeouts are nested, and the outer one must stay the longer.**
+  `PROOF_GENERATION_TIMEOUT_MS` (120 s) is the real budget — `offscreen.js` races
+  `createClaimOnAttestor` against it. `PROOF_RESPONSE_TIMEOUT_MS` is the background waiting for the
+  offscreen's reply, and is **derived** as `PROOF_GENERATION_TIMEOUT_MS + 15_000` rather than written as
+  a literal, because it was once 60 s against an inner 120 s: the outer always won, a proof legitimately
+  needing 60–120 s was killed while the offscreen was still working, and the inner timeout could never
+  surface. The outer is now only a backstop for a document that died without answering.
 
-- **extension-classic**: Content script (UMD), interceptor/offscreen (IIFE)
-- **background-esm-mv3**: Background + SDK as ES modules (Manifest V3)
-- **background-commonjs-mv2**: Background + SDK as CommonJS (Manifest V2/Firefox)
+  Both paths in [proof-generator.js](src/utils/proof-generator/proof-generator.js) reject with a real
+  `Error` (via the local `rejection()` helper). They used to reject a bare `{success, error}` literal, so
+  `error.message` in `proofQueue`'s catch was `undefined` — the session's one explanation of a proof
+  timeout read `Proof generation failed: undefined`, and that string reached the consumer's Promise.
+  `proofQueue` also reads `error?.message || error?.error` now, so the next plain-object rejection stays
+  legible.
 
-Output bundles in `build/`:
+- **`expectManyClaims`** lets a provider script defer submission until it flips the flag off; that
+  transition triggers `submitProofs` immediately if proofs are already queued.
+- **The content script — and its popup — is destroyed and rebuilt on every navigation.** It is injected
+  at `document_start` on each page, and a multi-request provider routinely walks several origins: the
+  stock `example` provider goes example.org → example.com → jsonplaceholder, re-running
+  `PROVIDER_DATA_READY`, the interceptor injection and the popup construction each time. **Nothing
+  accumulated in content-script state survives a claim boundary.**
 
-- `ReclaimExtensionSDK.bundle.js` - Main SDK entry
-- `background/background.bundle.js` - Service worker
-- `content/content.bundle.js` - Content script (must be classic, not ESM)
-- `offscreen/offscreen.bundle.js` + `offscreen.html`
-- `interceptor/network-interceptor.bundle.js`
-- `interceptor/injection-scripts.bundle.js`
+  The popup's claim counter learned this the hard way. It counted `totalClaims` from the
+  `CLAIM_CREATION_REQUESTED` messages it personally saw and `completedClaims` from
+  `PROOF_GENERATION_SUCCESS`, both starting at zero on every page — so a real 3-claim session showed
+  `1/1`, flashed `2/1` (completed can exceed a per-page total), and finished by rendering
+  `totalClaims/totalClaims`, i.e. `1/1` again. Session 2b46b57c39 generated and submitted all three
+  proofs correctly the whole time; only the display was wrong.
 
-## Key Dependencies
+  The background is the only context that spans the navigations, so it owns the numbers:
+  [claim-progress.js](src/utils/claim-progress.js) `claimProgress(ctx)` returns
+  `{completed: ctx.generatedProofs.size, total: max(requestData.length, completed)}` — bound as
+  `ctx.claimProgress()` for `proofQueue`, per the shared-context pattern — and rides along in both
+  messages' `data.progress`. The popup renders what it is given and falls back to its old increment only
+  when the field is absent. `total` takes the _larger_ of the two because `expectManyClaims` can produce
+  more claims than `requestData` declares, and a counter reading `4/3` is worse than one that grows.
 
-- `@reclaimprotocol/attestor-core` - Core proof generation library
-- `@reclaimprotocol/tls` - TLS implementation
-- `ethers` - Wallet/signature operations for session initialization
-- `snarkjs` - Zero-knowledge proof operations (browser excluded via overrides)
+  Its own module rather than a function in `background.js` so `node --test` can reach it: `background.js`
+  uses extensionless imports, which webpack resolves and Node's ESM loader does not.
+
+- **A rejected candidate is not a failed session.** Authoritative redaction resolution happens in the
+  background, so it can legitimately conclude "this response doesn't carry the data yet".
+  `processFilteredRequest` returns `{retryable: true}` for that case — no `failSession`, no
+  `CLAIM_CREATION_FAILED` — `messageRouter` un-memoizes `ctx.filteredRequests`, and the content script
+  pops the key back off `this.filteredRequests` so polling resumes. Skipping any one of those three
+  stalls the flow until the session timer fires.
+
+### The claim object must satisfy the attestor's schema exactly
+
+`params` / `secretParams` are validated **server-side** by AJV against attestor-core's
+`HttpProviderParameters` / `HttpProviderSecretParameters` (`src/types/providers.gen.ts`, applied in
+`server/utils/validation.ts`). Both are `additionalProperties: false`, AJV runs `strict: true` with no
+`removeAdditional`, so one unexpected key fails the whole claim with `ERROR_BAD_REQUEST: Params validation
+failed` — at proof time, after the user has logged in, with the field named only inside an errors blob.
+
+Provider documents legitimately carry fields that must **not** be forwarded (`order`, `description`,
+`isOptional`, the legacy `responseSelections`), and that set grows independently of this SDK. So:
+
+- [claim-shape.js](src/utils/claim-creator/claim-shape.js) `assertClaimShape()` is the last gate before the
+  attestor: an **allowlist** of the schema's keys, plus string coercion of `paramValues` (a
+  `customInjection` can hand back a number via `window.Reclaim`, which AJV rejects) and a required-field
+  check. It strips rather than throws — a dropped unknown field still yields an acceptable claim, whereas
+  failing the session denies a verification over a field the attestor would have ignored.
+- `responseRedactions` is likewise built as an allowlist (`xPath`, `jsonPath`, `regex`, `hash`). Empty
+  `xPath`/`jsonPath` are omitted, not sent as `""`.
+- **Never add a field to `params` without checking the schema first.**
+
+**Hash-bearing params stay in `params.paramValues` — do not force them secret.** It looks like a privacy
+win and breaks OPRF two ways: the attestor verifies response matches via
+`substituteParamValues(rawParams, undefined, true)` — `secretParams` is _undefined_ there, and
+`ignoreMissingParams` makes an unresolved `{{param}}` return **literally**, so the match is compared
+verbatim and never matches; and `updateParametersFromOprfData` (default `true`) replaces the raw value with
+the OPRF nullifier inside `params` only. Privacy comes from that client-side substitution, not from hiding
+the param. InApp splits on the name containing `SECRET` and nothing else — match that.
+
+### Provider values wider than this SDK supports
+
+[provider-normalization.js](src/utils/provider-normalization.js) coerces provider config to what the
+extension actually implements, at the point the provider is fetched, logging every coercion:
+
+| field                       | upstream value space                       | supported here                                       | fallback                                                                                                                                        |
+| --------------------------- | ------------------------------------------ | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `injectionType`             | `MSWJS \| XHOOK \| HAWKEYE \| NONE \| CDP` | `HAWKEYE` (inject the interceptor), `NONE` (don't)   | **`HAWKEYE`** — matches InApp's `defaultValue`. Never default to `NONE`: that silently disables interception and the session dies on the timer. |
+| `responseRedactions[].hash` | `oprf \| oprf-mpc \| oprf-raw`             | `oprf-raw`                                           | **`oprf-raw`** for any other truthy value. Absent/`null` must stay absent — coercing it would hash a value the provider meant to reveal.        |
+| `requestData[].urlType`     | `REGEX \| CONSTANT \| TEMPLATE`            | all three (`CONSTANT`/`EXACT` compare, others regex) | **inferred from the url** like InApp does: `TEMPLATE` if it contains `{{`, else `CONSTANT`. Never refuse to match — see below.                  |
+
+`injectionType` is normalized in `sessionManager.startVerification` right after `fetchProviderData`, so
+every downstream consumer sees a supported value; `messageRouter` sends `DEFAULT_INJECTION_TYPE` rather
+than `null` when there is no provider data.
+
+`urlType` is normalized where it is _used_ instead — in `matchesRequestCriteria`
+([network-filter.js](src/utils/claim-creator/network-filter.js)), the one place it decides anything. Two
+things to know:
+
+- **There is no `EXACT` upstream.** The enum is `REGEX | CONSTANT | TEMPLATE` (InApp `UrlType`).
+  `EXACT` is local to this SDK — `matchesRequestCriteria`'s historical default, and what the background
+  writes on synthetic requests — so it is kept as an alias for `CONSTANT`, not removed.
+- **An unrecognised `urlType` must never mean "no match".** This branch used to `return false` for
+  anything outside its list, and `CONSTANT` — upstream's _default_, what InApp infers for any url without
+  `{{` — was outside it. A provider carrying it matched no request at all: no claim, no proof, and no
+  diagnostic past `REQUEST_INTERCEPTED`, because everything that logs about extraction runs only _after_ a
+  match. It failed on the session timer looking exactly like "the user never logged in". Guessing wrong
+  costs one non-matching request; refusing to match costs the whole verification, so unknown values are
+  inferred from the url.
+
+#### The gate reports which check rejected a request
+
+This gate is upstream of every extraction log, so a provider that matches nothing used to be the one
+failure mode with no signal at all: the six `return false` points were silent, and a stale `bodySniff`
+template produced a session identical to "the user never logged in".
+
+`describeRequestMatch()` is now the real entry point and returns `{matched, stage, detail}`;
+`filterRequest()` is a thin boolean wrapper kept for callers that only need the verdict. `stage` is a
+member of `MATCH_STAGES`, ordered by `MATCH_STAGE_ORDER` (`url → method → body → responseMissing →
+responseMatch → responseRedaction → matched`), so **reaching stage N means every check before N passed** —
+that ordering is what the content script's counters are built on.
+
+- **`detail` becomes a log line, and log lines are never redacted.** Only provider-authored patterns
+  (the url template, `bodySniff.template`, `match.value`, a redaction's `jsonPath`/`regex`) and _sizes_
+  may appear in it. Never the request body, never the response. `network-filter.test.js` pins this.
+- **Only near misses are logged individually.** `content.js` `reportMatchAttempt()` skips
+  `MATCH_STAGES.URL` — 32 of 33 requests in a typical page load die there and it says nothing the
+  `REQUEST_INTERCEPTED` line doesn't. `responseMissing` is FINE, being the normal state on the tick
+  between a request and its response. Everything else is INFO.
+- **Reporting is keyed on advancement, not on evaluation.** Filtering re-runs every
+  `NETWORK_FILTERING_INTERVAL_MS` over the same request map for the life of the session, so
+  `this.matchProgress` (`"<matcherIndex>|<requestKey>"` → furthest stage index) gates each line to the
+  first time that pair gets that far. A request legitimately advances when its response arrives, so
+  dedupe on "seen" rather than "advanced" would suppress the interesting outcome.
+
+`reportNoMatchSummary()` closes the loop with one line per matcher (`N seen, N url-matched,
+N method-matched, N body-matched, N fully matched`), fired by a content-script timer armed in
+`startNetworkFiltering` and disarmed on the first match. This is the "no request ever matched" timer
+`RECLAIM_VERIFICATION_NO_ACTIVITY_DETECTED_EXCEPTION` was waiting for — but it carries that event type
+**only when nothing was intercepted at all**. With traffic seen it emits
+`CLAIM_CREATION_TIMED_OUT_EXCEPTION`, which is what the background's session timer already calls the same
+outcome. Deliberately **not** `FILTER_REQUEST_ERROR`: that marks a _thrown_ filtering error
+(`background.js`), and folding a clean non-match into it would break that query.
+
+The background's `SessionTimerManager` cannot do this job — it starts only on the first intercepted
+request, so it cannot tell "no traffic" from "traffic, none matching", and the counters live in the
+content script anyway.
+
+### Vendored attestor code — must be re-synced by hand
+
+A provider's `xPath` / `jsonPath` / `regex` is authored once and must resolve **identically** in
+attestor-core, the InApp SDK, and this extension. To guarantee that, the extraction primitives are a
+verbatim copy of the attestor's, not a reimplementation:
+
+| file                                                                                   | upstream source                                                                          |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [vendor/attestor-http-utils.js](src/utils/claim-creator/vendor/attestor-http-utils.js) | attestor-core `src/providers/http/utils.ts` (extraction half)                            |
+| [vendor/patch-parse5-tree.js](src/utils/claim-creator/vendor/patch-parse5-tree.js)     | attestor-core `src/providers/http/patch-parse5-tree.ts`                                  |
+| [attestor-extraction.js](src/utils/claim-creator/attestor-extraction.js)               | mirrors the private `processRedactionRequest` generator in `src/providers/http/index.ts` |
+| [make-regex.js](src/utils/claim-creator/make-regex.js)                                 | `makeRegex`, using the attestor's browser `re2` fallback semantics                       |
+
+Rules:
+
+- **Do not "improve" the vendored files.** Any local edit silently breaks cross-SDK parity. Deviations are
+  allowed only where the environment forces them, and each is commented (currently only `makeRegex`, which
+  is `new RegExp(str, "sgi")` rather than `RE2(str, 'sgiu')` — the attestor's own browser build does the
+  same, and webpack aliases `re2: false` here anyway).
+- **After re-syncing, run `npm test`.**
+  [attestor-parity.test.js](src/utils/claim-creator/attestor-parity.test.js) drives the _installed_
+  attestor through its `./external-rpc` `handleIncomingMessage` surface and diffs it against the copy, so
+  it catches real divergence rather than just re-asserting copied expectations.
+- The parsers (`xpath`, `parse5`, `parse5-htmlparser2-tree-adapter`, `domhandler`, `esprima-next`) are
+  pinned to the attestor's exact ranges. Bump them together with a re-sync, not independently.
+- **Keep them out of the content bundle.** They have import-time side effects (`patch-parse5-tree` mutates
+  `domhandler` prototypes) so webpack cannot tree-shake them, and the content script is injected at
+  `document_start` on every page of every site. That's why `content.js` imports `filterRequest` from
+  `claim-creator/network-filter` directly rather than the `claim-creator` barrel, why `makeRegex` lives in
+  its own module, and why the content-script gate has no `xPath` branch at all.
+
+Why vendored rather than imported, now that the pinned 5.1.1 _does_ export the extractors
+([PR #92](https://github.com/reclaimprotocol/attestor-core/pull/92)): `makeRegex` and the
+`processRedactionRequest` redaction chain are still not in that export set, so local copies are needed
+either way — and a half-imported, half-copied chain is harder to keep in lockstep than a wholly copied
+one `attestor-parity.test.js` can diff end to end. That test runs on 5.1.1 (it skipped on 5.0.5), so the
+copies are now checked against the real attestor on every `npm test` rather than trusted.
+
+### attestor-core is pinned to `5.1.1` exactly — do not bump it casually
+
+`@reclaimprotocol/attestor-core` is pinned **without `^`**. Two independent regressions in the 5.0.x/5.1.x
+line make several versions unusable, and neither fails at install time:
+
+| version      | `./browser` bundle ships | bundle registers `stwo` |
+| ------------ | ------------------------ | ----------------------- |
+| 5.0.5        | yes                      | yes                     |
+| 5.0.6        | yes                      | **no**                  |
+| 5.0.7        | yes                      | **no**                  |
+| 5.0.8        | yes                      | **no**                  |
+| 5.1.0-dev.1  | yes                      | yes (but a prerelease)  |
+| 5.1.0        | **no — 404**             | n/a                     |
+| **5.1.1** ✅ | yes                      | **yes**                 |
+
+- 5.1.0 dropped `browser/resources/attestor-browser.min.mjs` from the tarball (unpacked size
+  2.64 MB → 1.02 MB) while still declaring `exports["./browser"]`, which
+  [offscreen.js](src/offscreen/offscreen.js) imports. Resolution fails at build time. 5.1.1 restored it
+  (2.58 MB unpacked, 1.55 MB bundle).
+- 5.0.6–5.0.8 still ship that bundle, but it no longer registers a ZK operator maker for `stwo` — the
+  engine [config.js](src/utils/constants/config.js) `DEFAULT_ZK_ENGINE` selects. Nothing complains until
+  proof time, when the offscreen document throws
+  `Proof generation failed: No ZK operator maker for stwo` — _after_ the user has logged into the
+  provider. `browser/resources/*.mjs` is a checked-in artifact built by a separate step upstream, which is
+  how its contents drift between patch releases.
+
+[attestor-zk-engine.test.js](src/utils/claim-creator/attestor-zk-engine.test.js) guards both: it asserts
+the pinned version ships the bundle and that the bundle references `DEFAULT_ZK_ENGINE`. **Run `npm test`
+after any attestor bump** — that test turns both regressions from a runtime failure into a test failure.
+
+**What a bump has to be checked against**, beyond that test — all of it verified for 5.1.1:
+
+- `exports["./browser"]` resolves and the bundle exports `createClaimOnAttestor`
+  ([offscreen.js](src/offscreen/offscreen.js)); `exports["./external-rpc"]` exports
+  `handleIncomingMessage` (the parity test's only route in).
+- The ZK operator-maker registry in the **built** `build/offscreen/offscreen.bundle.js` — not just the
+  package's copy — has a top-level `stwo` key. That is the object the
+  `No ZK operator maker for ${engine}` throw reads.
+- `CreateClaimOnAttestorOpts` still intersects `PrepareZKProofsBaseOpts`, which is what puts `zkEngine`
+  at the top level of the object [claim-creator.js](src/utils/claim-creator/claim-creator.js) builds, and
+  `updateParametersFromOprfData` still exists (the OPRF note above depends on its default).
+- `HttpProviderParameters` / `HttpProviderSecretParameters` in `lib/types/providers.gen.d.ts` against the
+  allowlists in [claim-shape.js](src/utils/claim-creator/claim-shape.js). Note
+  `supportedProtocolVersions`, added in the 5.1 line, is nested under `additionalClientOptions`, not
+  top-level — the allowlists still match exactly.
+
+  5.1.1 also ships `lib/` as **ESM**. On 5.0.5 those were esbuild bundles doing named imports from the
+  CommonJS `@reclaimprotocol/tls`, which Node's ESM loader refuses, so the package could not be loaded
+  under Node and [attestor-parity.test.js](src/utils/claim-creator/attestor-parity.test.js) — the
+  differential check of the vendored extraction code against the real attestor — **skipped**. It now runs
+  and passes, which is the strongest available evidence that the vendored copies are still in sync. The
+  suite went 148 tests/1 skipped → 159 tests/0 skipped on this bump alone. The skip path is kept in case a
+  future pin regresses to the CJS shape.
+
+### Messaging
+
+Three separate action vocabularies, all in [src/utils/constants/interfaces.js](src/utils/constants/interfaces.js):
+
+- `RECLAIM_SDK_ACTIONS` (`RECLAIM_*`) — web page ↔ content script over `window.postMessage`.
+- `MESSAGE_ACTIONS` — content ↔ background ↔ offscreen over `chrome.runtime` / `chrome.tabs`.
+- `MESSAGE_SOURCES` — every internal message carries `{action, source, target, data}`, and
+  [messageRouter.js](src/background/messageRouter.js) validates `source`/`target` plus
+  `ctx.managedTabs.has(sender.tab.id)` before acting. Adding a handler means adding a case _and_
+  the matching guard; unmanaged tabs must be rejected.
+
+### Provider-facing page API
+
+[injection-scripts.js](src/interceptor/injection-scripts.js) installs `window.Reclaim` in the MAIN world
+for provider-authored `customInjection` scripts: `parameters` (getter), `getParametersSync()`,
+`updatePublicData()`, `canExpectManyClaims()`, `reportProviderError()`, `requestClaim()`. Each posts a
+`RECLAIM_*` message that the content script forwards to background. Changing these signatures breaks
+published provider scripts.
+
+### CSP stripping
+
+When `providerData.extensionConfig.allowInjectionsViaChromeScripting` is set, `cspRuleManager` adds a
+`declarativeNetRequest` **session** rule (fixed id `CSP_RULE_ID = 9999`) that strips the provider
+origin's CSP so `chrome.scripting.executeScript` can `eval` the custom injection in the MAIN world. It
+is removed on session end, on tab close, on `startVerification` failure, at background init (orphan
+cleanup), and by a `CSP_RULE_MAX_LIFETIME_MS` safety timer. Any new exit path needs the same cleanup.
+
+### Offscreen document
+
+`installOffscreenReadyListener()` runs at background init; `ensureOffscreenDocument()` creates the
+document on demand and waits for `OFFSCREEN_DOCUMENT_READY`. Proof generation is only reachable through
+`GENERATE_PROOF` / `GENERATE_PROOF_RESPONSE` messages — the offscreen document exists because
+attestor-core needs WASM, real WebSockets, and `crypto.getRandomValues`, none of which are usable
+directly from an MV3 service worker.
+
+## Build output and bundle-format constraints
+
+Three webpack configs in [webpack.config.js](webpack.config.js), all writing into a single `build/`
+(`clean: false` after the first, so build order matters):
+
+1. `extension-classic` — content script as **UMD** (`ReclaimContent`), interceptor + offscreen as
+   classic scripts. The content script must not be ESM: an MV3 `content_scripts` entry loading an
+   ES module fails with `Unexpected token 'export'`.
+2. `background-esm-mv3` — `background/background.bundle.js` + `ReclaimExtensionSDK.bundle.js` as ES
+   modules (`output.module`, `experiments.outputModule`).
+3. `background-commonjs-mv2` — the same two entries as `*-mv2.bundle.js` in CommonJS for Firefox/MV2.
+
+attestor-core drags in Node built-ins, so `commonResolve` aliases `koffi`/`re2`/`snarkjs` to `false`,
+maps `worker_threads`/`jsdom`/`module` to stubs in [src/utils/mocks/](src/utils/mocks/), and points `ws`
+at [websocket-polyfill.js](src/utils/websocket-polyfill.js). The same exclusions are duplicated in
+`package.json`'s `overrides` and `browser` fields — a new native-dep failure usually needs entries in
+both places. `ignoreWarnings` in the first config deliberately silences the resulting resolution noise.
+
+`__SDK_VERSION__` is a DefinePlugin global injected from `package.json`; the SDK reports it as
+`ext-<version>` in `sdkVersion`.
 
 ## Logging
 
-The SDK includes a logger utility (`src/utils/logger/`) that sends diagnostic logs to Grafana:
+Background writes directly to the singleton `loggingHub`; content and offscreen use
+`createRemoteLogger("content" | "offscreen")`, which forwards `LOG_MESSAGE` to the hub so all logs are
+enriched with one session context and batched to the remote endpoint.
 
 ```javascript
-import { log, logError, loggerService } from "../utils/logger";
+// background
+import { loggingHub } from "../utils/logger/LoggingHub";
+loggingHub.info(message, "background.verification"); // also .debug / .warn / .error
 
-log(message, type, sessionId, providerId, appId);
-logError(error, type, sessionId, providerId, appId, message);
+// content or offscreen
+import { createRemoteLogger } from "../utils/logger/RemoteLogger";
+const logger = createRemoteLogger("content");
 ```
 
-Debug logging uses `debugLogger` with `DebugLogType` constants (BACKGROUND, CONTENT, OFFSCREEN).
+MAIN-world scripts (`src/interceptor/`) have no `chrome.runtime`, so they use
+[log-bridge.js](src/interceptor/log-bridge.js) `createPageLogger(context, category)`, which
+`window.postMessage`s `RECLAIM_LOG`; `content.js` relays it via `logger.relay()` with the _originating_
+context preserved. Never add a bare `console.log` in the interceptor — it would reach neither the
+endpoint nor the config gate.
 
-## Consumer Integration
+The second argument is a dotted category (`background.claim`, `background.csp`, …) used for filtering
+downstream — reuse an existing one where it fits. `loggingHub.setSessionContext()` is called on
+`START_VERIFICATION`; `clearSessionContext()` is `await`ed on every terminal path and **flushes first**,
+because a terminal event is exactly when the worker is most likely to be torn down.
 
-Consumers must:
+- **`flush()` is serialized, never skipped, and must stay that way.** It chains each call onto the
+  previous one instead of returning early while a POST is in flight. Returning early loses the caller's
+  batch, and the two callers that overlap in practice are the periodic flush and the terminal
+  `clearSessionContext()` — so the dropped batch is the end of a failed session, the only part that
+  explains the failure. This was a real loss: a session's logs stopped dead at the last periodic flush and
+  the proof-failure tail never reached the endpoint, while the console showed it all. `forceFlush()` is now
+  just `flush()`; the previous version polled `isFlushing` for one second and then called a `flush()` that
+  no-opped anyway. [logging-hub.test.js](src/utils/logger/logging-hub.test.js) `"never skips a batch"`
+  keeps a slow (1.2 s) first POST in the way of a terminal flush and fails if the terminal batch vanishes.
+- **`clearSessionContext()` keeps the identifiers.** A terminal path is not the last thing that logs —
+  `failSession` goes on to notify tabs, broadcast to the popup and answer further messages. Nulling the
+  ids stamped those `"unknown"`, which makes them unreachable from a `sessionId` query and therefore
+  invisible in the legacy log viewer. `sessionEnded` records the transition instead; the next
+  `setSessionContext()` overwrites the ids. Over-attributing a stray inter-session line is much cheaper
+  than losing the failure tail.
+- **`alarms` is in the recommended consumer manifest.** Without it `_startFlushSchedule()` falls back to
+  `setInterval`, which Chrome destroys along with the service worker. The fallback stays (no consumer is
+  forced to change a manifest) but the example manifest and `readme.md` now ask for the permission.
 
-1. Run `npm run reclaim-extension-setup` to copy assets to their public folder
-2. Add required manifest entries (CSP, permissions, web_accessible_resources)
-3. Call `reclaimExtensionSDK.initializeBackground()` in their service worker
-4. Load `content.bundle.js` via manifest or dynamic registration
+Non-obvious properties:
+
+- **One threshold, and it decides redaction.** `config.logLevel` governs the console _and_ the endpoint,
+  and the two destinations always receive the same text. `INFO` (the default) redacts every payload;
+  `FINE` serialises it raw. `config.consoleEnabled` is independent and only mirrors lines locally.
+
+  There used to be a second threshold, `remoteLogLevel`, defaulting to `DEBUG` so "everything ships".
+  Combined with a destination-based redaction split (console raw, endpoint redacted) it could not express
+  the property that actually matters — _no user data anywhere at the default level_ — and in practice it
+  published `claimData.context.extractedParameters` (the plaintext value being proven) to Loki on every
+  successful session. Don't reintroduce it: the way to get more detail is to raise `logLevel` to `FINE`,
+  which is also the switch that stops redacting.
+
+- **Levels use the platform's spelling: `SEVERE` → `WARNING` → `INFO` → `FINE`.** The InApp SDK, the
+  Portal and the log viewer all speak Java-style levels, and the logs API only accepts
+  `fine | config | info | warning | severe` when filtering by severity — the old `ERROR`/`WARN`/`DEBUG`
+  spellings made extension sessions unfilterable next to everyone else's. `normalizeLogLevel()` in
+  [logger/constants.js](src/utils/logger/constants.js) still resolves the old names (and `CONFIG`,
+  `FINER`, `FINEST`) so a persisted consumer config keeps working. The method names are unchanged —
+  `loggingHub.debug()` emits `FINE`, `.error()` emits `SEVERE` — because every call site uses them;
+  `.fine()` exists as an alias.
+
+  `WARNING` and `SEVERE` are _more_ severe than `INFO`, so they are always visible at the default. The
+  labels exist so one query can isolate failures, never to hide them.
+
+- **The queue is mirrored to `chrome.storage.session`** on every change and drained at hub init. MV3 kills
+  the worker without warning and `onSuspend` is unreliable, so an in-memory-only queue loses precisely
+  the logs that explain a crash. `chrome.alarms` is used for the periodic flush when the consumer's
+  manifest grants it, with `setInterval` as the fallback so no manifest change is forced.
+- **The hub starts lazily.** `ReclaimExtensionSDK.js` imports `background.js` at module scope, so eager
+  construction would start a flush schedule in every consumer popup and web page.
+- **Every entry carries `source`** — the versioned identity from
+  [client-source.js](src/utils/logger/client-source.js), e.g.
+  `browser-extension-sdk sdk/v0.4.2 (chrome/141,<ext-id>/v1.0.0)` — plus `context`
+  (background|content|offscreen|interceptor|injection), `sessionId`, `providerId`, `appId`. The grammar
+  mirrors the InApp SDK's `getClientSource()`; the team's SDK-identification rule is a substring check for
+  `browser-extension-sdk`, so no code path may produce a string without it.
+- **Redaction follows the _level_, not the destination.** Pass structured data as the third argument —
+  `loggingHub.info("Starting:", "background.verification", { payload: templateData })`. At `INFO` the hub
+  redacts it once and hands that same redacted copy to both the console (as a second console arg, so
+  devtools still renders a tree) and the endpoint, capped at `LOG_MAX_LINE_LENGTH`. At `FINE` both get the
+  raw object, capped at `LOG_MAX_UNREDACTED_LINE_LENGTH`. `RemoteLogger`/`relay()`/the page bridge all
+  carry `payload` as an object across the boundary (structured-cloned) so this holds for every context.
+
+  The console deliberately gets a redacted _copy_ rather than the caller's object at `INFO`: the
+  content-script console is the **provider tab's** console, so "the console always shows everything" meant
+  a consumer who enabled it was printing the user's own extracted data into the site they were logged in
+  to.
+
+  **Never pre-stringify at the call site** — `info("x: " + JSON.stringify(obj))` sends whatever `obj`
+  holds straight to Loki. The router used to do exactly that with the whole `templateData`, publishing the
+  session `signature` and the user's `parameters`. `redact.js` matches sensitive keys by substring
+  (`signature`, `secret`, `token`, …) and blanks the _values_ of `parameters`/`paramValues` while keeping
+  their key names, which is usually the actual diagnostic question.
+
+  **Response content is never allowed in a message string.** `RedactionResolveError` used to interpolate
+  up to 200 characters of the matched element into its message
+  (`regexp X does not match found element '<...>'`), and that message becomes the `logLine` — so every
+  regex miss on a matched request published a slice of the user's authenticated page to Loki. Key-based
+  redaction cannot save free text in `message`. The content now travels as `error.element` and is passed
+  through the log **payload**; `RESPONSE_CONTENT_KEYS` in [redact.js](src/utils/logger/redact.js) replaces
+  such string values with `<redacted:N chars>` at `INFO`. That list is deliberately narrow — bare `body` is
+  excluded, because a claim's `params.body` is a provider-authored template worth reading, not user data.
+
+  The backend redacts unconditionally too
+  ([sanitize.ts](../reclaim-logs-backend/src/utils/sanitize.ts) blanks `deviceId`, `publicIpAddress`,
+  `userAgent`, `metadata` on every `logDump`) — but it never touches `logLine`, so anything embedded in a
+  message string reaches Loki verbatim regardless.
+
+- **Two shapes redaction handles specially, both learned from real leaks.**
+
+  `OPAQUE_KEYS` (`claimData`, `context`, `extractedParameters`, `injectionResult`) are replaced whole with
+  `[REDACTED]` rather than walked into. `claimData` is the attestor's claim, and `claimData.context`
+  carries `extractedParameters` — the plaintext value the user is proving. Descending key-by-key would
+  expose every field the attestor adds in future until someone remembered to list it, and the InApp SDK
+  blanks exactly this field in its own `PROOF_GENERATED` line, so a redacted proof reads the same across
+  SDKs: identifier, signatures, witnesses and `providerRequest` survive, the payload does not.
+
+  `USER_DATA_KEYS` are matched **whatever the value's type is**. The attestor hands `parameters`,
+  `publicData` and friends back as JSON _strings_, and an `isUserData(key) && typeof val === "object"`
+  guard let those blobs through untouched — which is how the proven value reached Loki on every successful
+  session. An object keeps its key names (`<redacted keys: username>`); a string keeps only its length.
+
+- **The full-claim dumps are just `FINE` now.** [claim-creator.js](src/utils/claim-creator/claim-creator.js)
+  after `assertClaimShape`, and [offscreen.js](src/offscreen/offscreen.js) immediately before
+  `createClaimOnAttestor` — the latter being the only view of the object that actually reached the
+  attestor, after `sessionId` is stripped and the chrome-messaging hop. An attestor-side rejection
+  (`Params validation failed`, a response match that never matches) is diagnosable only from the exact
+  bytes sent, and the redacted form blanks `secretParams`, `paramValues` and `ownerPrivateKey` — the fields
+  most likely to be at fault.
+
+  These used to carry a per-call `unredacted: true` flag with its own gate. That flag is **gone**: the
+  level decides, so there is no longer a way for a call site to opt out of redaction independently of the
+  configured level. `LOG_MAX_UNREDACTED_LINE_LENGTH` (100 000, vs `LOG_MAX_LINE_LENGTH` 2000) now applies
+  to any `FINE` payload, since a real claim runs well past 2000 characters.
+
+  [logging-hub.test.js](src/utils/logger/logging-hub.test.js) `"no user data reaches the endpoint at the
+default level"` pins the corners: claim blanked at the stock defaults, `claimData` blanked inside a
+  submitted proof, a provider script's return value blanked whatever keys it invents, the message itself
+  preserved, and all of it raw at `FINE` including across the relay.
+
+- **Why the matched request failed is reported per stage.** `RedactionResolveError` carries `stage`
+  (`xPath` | `jsonPath` | `regex` | `responseMatch` | `redaction`), and `reportExtractionFailure` in
+  [background.js](src/background/background.js) maps it to the InApp SDK's own four names —
+  `X_PATH_MATCH_REQUIREMENT_FAILED` / `JSON_PATH_MATCH_REQUIREMENT_FAILED` (error) and
+  `REGEX_MATCH_REQUIREMENT_FAILED` / `NO_RESPONSE_MATCH_WARNING` (warning), matching
+  `claim_creation.dart`'s severities so one query spans both SDKs. This lives in the background because
+  that is the only place authoritative resolution happens, and it therefore only ever runs for a request
+  the content gate already matched — the content gate itself must stay a cheap presence check. Only one
+  stage can fail per attempt, so this re-labels the single line that was already emitted rather than
+  multiplying it; repeats of the same `(requestHash, stage, message)` drop to `FINE` via
+  `ctx.reportedExtractionFailures`, because the content script re-polls every
+  `NETWORK_FILTERING_INTERVAL_MS` for the life of the session timer.
+- **Extraction success is reported too, and it is INFO.** For a long time only _failures_ were, so a
+  selector that resolved to the wrong region — or to an empty string — looked exactly like one that was
+  never evaluated, and the session's only extraction line was
+  `[PARAM-EXTRACTOR] Validating N response match(es)`. `extractParamsFromResponse`
+  ([params-extractor.js](src/utils/claim-creator/params-extractor.js)) now emits a line per resolved
+  redaction (`Redaction #0 resolved via jsonPath: $.user.userName → 1 slice(s) [len=24]`) and per
+  satisfied responseMatch, plus the `Resolved N param(s)` summary — all carrying the provider's selector
+  and the value's **length**, never the value.
+
+  What makes INFO safe here is that the values ride the log **payload** under the key
+  `extractedParameters`, which is in `OPAQUE_KEYS`: `[REDACTED]` at INFO, raw at FINE. Keep new
+  extraction logging to that shape — a value interpolated into the message string would reach Loki
+  verbatim on every successful session, which is the exact regression `redact.js` exists to prevent.
+
+- **`SessionTimerManager` logs through the hub.** [session-timer.js](src/utils/session-timer.js) is
+  imported only by `background.js`, so it can import `loggingHub` directly without breaking the hub's
+  lazy start. Its lines were bare `console.log` — simultaneously the only part of the flow visible in a
+  stock local console and the only part unreachable from a `sessionId` query.
+
+  [polyfills.js](src/utils/polyfills.js) **cannot** do the same: it is imported by
+  `ReclaimExtensionSDK.js`, so it runs in the consumer's own web page, where importing the hub would
+  start a flush schedule (and `createRemoteLogger` has no `chrome.runtime`). Its happy-path chatter was
+  removed instead; the `console.warn`/`console.error` failure paths stay.
+
+- **Dedupe counts, it doesn't discard**: a repeat inside `LOG_DEDUPE_WINDOW_MS` bumps `repeated` on the
+  queued entry. The key is `context|level|message|type`, so the same wording from two contexts stays two
+  entries.
+
+Log level and console output come from `chrome.storage.local` under `LOG_CONFIG_STORAGE_KEY` and can be
+set by consumers via `reclaimExtensionSDK.setLogConfig()` or `init(..., { logConfig })`. Defaults:
+`logLevel: "INFO"`, `consoleEnabled: false` — nothing sensitive is collected and the console stays quiet
+until asked, because the content-script console is the _provider tab's_ console and a consumer extension
+ships to end users. For local work: `setLogConfig({ consoleEnabled: true, logLevel: "FINE" })`.
+
+`FINE` sends response bodies, extracted values, the full claim (owner private key, session cookies) and
+the full proof **to the endpoint as well** — that is the point of it, since a client's failing session has
+to be diagnosable remotely. It is the same trade the Portal makes with its per-session `log: true` flag.
+Prefer setting it per verification via `init(..., { logConfig })` rather than leaving it on a device.
+
+`content.js` pushes the config into the MAIN world as `RECLAIM_LOG_CONFIG`, since the page world cannot
+read `chrome.storage` itself. [log-bridge.js](src/interceptor/log-bridge.js) therefore keeps its own copy
+of the defaults — **keep the two in sync**; it cannot import them, being dependency-free by design.
+
+### `eventType` — the cross-SDK taxonomy
+
+`EVENT_TYPES` in [logger/constants.js](src/utils/logger/constants.js) is reconciled against the InApp
+SDK's `LogEventType` (`reclaim-inapp-sdk/lib/src/logging/event_type.dart`). **If a name exists upstream,
+spell it the same way** — the point is that one Grafana query spans both SDKs. Before adding a name, look
+for one that already means the same thing; the file's header records the renames already made, and
+[logging-hub.test.js](src/utils/logger/logging-hub.test.js) fails if a retired extension-local name
+(`CLAIM_CREATION_SUCCESS`, `VERIFICATION_FLOW_FAILED`, …) comes back.
+
+Pass it alongside the category, both being separate axes — `eventType` answers "where in the flow",
+`type` answers "which module":
+
+```javascript
+loggingHub.info("[BACKGROUND] Fetched provider data …", "background.provider", {
+  eventType: EVENT_TYPES.FETCHED_PROVIDERS,
+});
+```
+
+`EVENT_TYPES` reaches the background modules through `ctx` (they take `ctx` first and import nothing —
+see the shared-context pattern above); `proofQueue` destructures it. Entries default to `"UNKNOWN"` rather
+than omitting the field, so it can be a Loki label without holes. MAIN-world callers use the bridge's
+`debug.event(EVENT_TYPES.X, …)`, kept separate from the level methods so the variadic console-style
+signature stays intact.
+
+`failSession(ctx, message, requestHash, eventType)` takes an optional event type, defaulting to
+`RECLAIM_EXCEPTION`. The session timer passes `CLAIM_CREATION_TIMED_OUT_EXCEPTION` — and note it can only
+fire _after_ the first intercepted request, which is why
+`RECLAIM_VERIFICATION_NO_ACTIVITY_DETECTED_EXCEPTION` is emitted from the **content script's** no-match
+timer instead, and only when nothing was ever intercepted. See "The gate reports which check rejected a
+request" above.
+
+## `reclaim-api-client`
+
+Every request to a **Reclaim-owned** endpoint carries `reclaim-api-client: <client source>`, matching what
+the InApp SDK and Verifier app send — `fetchProviderData`, `updateSessionStatus`
+([fetch-calls.js](src/utils/fetch-calls.js)), `_initSession`
+([ReclaimExtensionSDK.js](src/ReclaimExtensionSDK.js)), and the `logDump` POST.
+
+Deliberately **not** on `submitProofOnCallback`: `submitUrl` is the consumer's own server, `Content-Type:
+text/plain` keeps that a CORS-safelisted "simple" request today, and adding a custom header would force an
+OPTIONS preflight arbitrary consumer servers need not answer. Both Reclaim backends run `cors()` with
+defaults, so they reflect the header on preflight — verified, but re-check before adding the header to a
+new host.
+
+Per the team's guideline the extension contributes **no device information to analytics**: request bodies
+are unchanged, so `deviceId`/`deviceType` stay absent and the backend records them as `NA`. The extension
+emits no `appLogs` of its own — the `USER_STARTED_VERIFICATION` analytics row is created server-side by
+reclaim-sdk-backend in response to `updateSessionStatus`, and there is no extension equivalent of InApp's
+`FETCHED_PROVIDERS`.
+
+## Docs that drift
+
+[readme.md](readme.md) is the accurate consumer-facing integration guide (assets, manifest, permissions,
+troubleshooting). The per-module READMEs
+([background](src/background/README.md), [content](src/content/README.md),
+[offscreen](src/offscreen/README.md), [logger](src/utils/logger/README.md)) predate several refactors —
+they still reference `debugLogger`/`DebugLogType`, `loggerService`, and `ProviderVerificationPopup.js`,
+none of which exist. Read them for intent, verify against source, and prefer updating them over
+propagating their examples.

--- a/examples/basic-extension/package-lock.json
+++ b/examples/basic-extension/package-lock.json
@@ -26,21 +26,25 @@
     },
     "../..": {
       "name": "@reclaimprotocol/browser-extension-sdk",
-      "version": "0.3.0",
+      "version": "0.5.0-dev.1",
       "license": "MIT",
       "dependencies": {
         "@extism/extism": "^1.0.3",
-        "@reclaimprotocol/attestor-core": "^5.0.5",
+        "@reclaimprotocol/attestor-core": "5.1.1",
         "@reclaimprotocol/tls": "git+https://git@github.com/reclaimprotocol/tls.git#8e0669a220341432673a20bb51f9339555701ef4",
         "@reclaimprotocol/zk-symmetric-crypto": "^5.1.3",
         "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "child_process": "^1.0.2",
         "crypto-browserify": "3.12.1",
+        "domhandler": "^5.0.3",
+        "esprima-next": "^5.8.4",
         "ethers": "^6.13.1",
-        "jsonpath-plus": "^10.3.0",
+        "jsonpath-plus": "^10.4.0",
         "os-browserify": "^0.3.0",
         "p-queue": "^8.0.1",
+        "parse5": "^8.0.0",
+        "parse5-htmlparser2-tree-adapter": "^8.0.0",
         "path-browserify": "1.0.1",
         "process": "^0.11.10",
         "react": "^18.2.0",
@@ -55,7 +59,8 @@
         "stream-browserify": "^3.0.0",
         "tailwindcss": "^3.3.3",
         "web-vitals": "^2.1.4",
-        "web3": "^4.10.0"
+        "web3": "^4.10.0",
+        "xpath": "^0.0.34"
       },
       "devDependencies": {
         "@babel/core": "^7.20.12",
@@ -124,10 +129,18523 @@
         "zip-webpack-plugin": "^4.0.1"
       }
     },
+    "../../node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "license": "MIT"
+    },
+    "../../node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "../../node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/compat-data": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/core": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "../../node_modules/@babel/eslint-parser": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "../../node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/@babel/generator": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "regexpu-core": "^6.2.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.6.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "debug": "^4.4.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.22.10"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "../../node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-module-transforms": {
+      "version": "7.27.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-wrap-function": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/helper-replace-supers": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helper-wrap-function": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/helpers": {
+      "version": "7.28.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/parser": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-proposal-class-properties": {
+      "version": "7.18.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-decorators": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.18.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-proposal-numeric-separator": {
+      "version": "7.18.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-proposal-optional-chaining": {
+      "version": "7.21.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-proposal-private-methods": {
+      "version": "7.18.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-remap-async-to-generator": "^7.27.1",
+        "@babel/traverse": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-remap-async-to-generator": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-classes": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/traverse": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/template": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-flow": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-literals": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.28.0",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.27.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.28.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-runtime": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-spread": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "../../node_modules/@babel/preset-env": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.27.1",
+        "@babel/plugin-syntax-import-attributes": "^7.27.1",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.28.0",
+        "@babel/plugin-transform-async-to-generator": "^7.27.1",
+        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.0",
+        "@babel/plugin-transform-class-properties": "^7.27.1",
+        "@babel/plugin-transform-class-static-block": "^7.27.1",
+        "@babel/plugin-transform-classes": "^7.28.0",
+        "@babel/plugin-transform-computed-properties": "^7.27.1",
+        "@babel/plugin-transform-destructuring": "^7.28.0",
+        "@babel/plugin-transform-dotall-regex": "^7.27.1",
+        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+        "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
+        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+        "@babel/plugin-transform-for-of": "^7.27.1",
+        "@babel/plugin-transform-function-name": "^7.27.1",
+        "@babel/plugin-transform-json-strings": "^7.27.1",
+        "@babel/plugin-transform-literals": "^7.27.1",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
+        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+        "@babel/plugin-transform-modules-amd": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-modules-systemjs": "^7.27.1",
+        "@babel/plugin-transform-modules-umd": "^7.27.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+        "@babel/plugin-transform-new-target": "^7.27.1",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
+        "@babel/plugin-transform-numeric-separator": "^7.27.1",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.0",
+        "@babel/plugin-transform-object-super": "^7.27.1",
+        "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/plugin-transform-private-methods": "^7.27.1",
+        "@babel/plugin-transform-private-property-in-object": "^7.27.1",
+        "@babel/plugin-transform-property-literals": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.28.0",
+        "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+        "@babel/plugin-transform-reserved-words": "^7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+        "@babel/plugin-transform-spread": "^7.27.1",
+        "@babel/plugin-transform-sticky-regex": "^7.27.1",
+        "@babel/plugin-transform-template-literals": "^7.27.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+        "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.14",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
+        "core-js-compat": "^3.43.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "../../node_modules/@babel/preset-react": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-transform-react-display-name": "^7.27.1",
+        "@babel/plugin-transform-react-jsx": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
+        "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/template": {
+      "version": "7.27.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/traverse": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@babel/types": {
+      "version": "7.28.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "../../node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.2.2",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "../../node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "../../node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "../../node_modules/@csstools/postcss-cascade-layers": {
+      "version": "4.0.6",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/selector-specificity": "^3.1.1",
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-cascade-layers/node_modules/@csstools/selector-specificity": {
+      "version": "3.1.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "../../node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-function": {
+      "version": "3.0.19",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^2.0.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-function/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-function/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-function/node_modules/@csstools/css-color-parser": {
+      "version": "2.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "@csstools/css-calc": "^1.2.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-function/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-function/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-mix-function": {
+      "version": "2.0.19",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^2.0.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-mix-function/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-mix-function/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-mix-function/node_modules/@csstools/css-color-parser": {
+      "version": "2.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "@csstools/css-calc": "^1.2.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-mix-function/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-color-mix-function/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-content-alt-text": {
+      "version": "1.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-content-alt-text/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-content-alt-text/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-exponential-functions": {
+      "version": "1.0.9",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-calc": "^1.2.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-exponential-functions/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-exponential-functions/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-exponential-functions/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-font-format-keywords": {
+      "version": "3.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/utilities": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gamut-mapping": {
+      "version": "1.0.11",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^2.0.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gamut-mapping/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gamut-mapping/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gamut-mapping/node_modules/@csstools/css-color-parser": {
+      "version": "2.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "@csstools/css-calc": "^1.2.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gamut-mapping/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gamut-mapping/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gradients-interpolation-method": {
+      "version": "4.0.20",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^2.0.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gradients-interpolation-method/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gradients-interpolation-method/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gradients-interpolation-method/node_modules/@csstools/css-color-parser": {
+      "version": "2.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "@csstools/css-calc": "^1.2.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gradients-interpolation-method/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-gradients-interpolation-method/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-hwb-function": {
+      "version": "3.0.18",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^2.0.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-hwb-function/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-hwb-function/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-hwb-function/node_modules/@csstools/css-color-parser": {
+      "version": "2.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "@csstools/css-calc": "^1.2.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-hwb-function/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-hwb-function/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-ic-unit": {
+      "version": "3.0.7",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-initial": {
+      "version": "1.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-is-pseudo-class": {
+      "version": "4.0.8",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/selector-specificity": "^3.1.1",
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-is-pseudo-class/node_modules/@csstools/selector-specificity": {
+      "version": "3.1.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "../../node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-light-dark-function": {
+      "version": "1.0.8",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-light-dark-function/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-light-dark-function/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-logical-float-and-clear": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-logical-overflow": {
+      "version": "1.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-logical-overscroll-behavior": {
+      "version": "1.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-logical-resize": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-logical-viewport-units": {
+      "version": "2.0.11",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-logical-viewport-units/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-media-minmax": {
+      "version": "1.1.8",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^1.2.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/media-query-list-parser": "^2.1.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-media-minmax/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-media-minmax/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-media-minmax/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-media-minmax/node_modules/@csstools/media-query-list-parser": {
+      "version": "2.1.13",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-media-queries-aspect-ratio-number-values": {
+      "version": "2.0.11",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/media-query-list-parser": "^2.1.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-media-queries-aspect-ratio-number-values/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-media-queries-aspect-ratio-number-values/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-media-queries-aspect-ratio-number-values/node_modules/@csstools/media-query-list-parser": {
+      "version": "2.1.13",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-nested-calc": {
+      "version": "3.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/utilities": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-normalize-display-values": {
+      "version": "3.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-oklab-function": {
+      "version": "3.0.19",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^2.0.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-oklab-function/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-oklab-function/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-oklab-function/node_modules/@csstools/css-color-parser": {
+      "version": "2.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "@csstools/css-calc": "^1.2.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-oklab-function/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-oklab-function/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-progressive-custom-properties": {
+      "version": "3.3.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-relative-color-syntax": {
+      "version": "2.0.19",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^2.0.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-relative-color-syntax/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-relative-color-syntax/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-relative-color-syntax/node_modules/@csstools/css-color-parser": {
+      "version": "2.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "@csstools/css-calc": "^1.2.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-relative-color-syntax/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-relative-color-syntax/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-scope-pseudo-class": {
+      "version": "3.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-scope-pseudo-class/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-stepped-value-functions": {
+      "version": "3.0.10",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-calc": "^1.2.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-stepped-value-functions/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-stepped-value-functions/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-stepped-value-functions/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-text-decoration-shorthand": {
+      "version": "3.0.7",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-text-decoration-shorthand/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-trigonometric-functions": {
+      "version": "3.0.10",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-calc": "^1.2.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/postcss-trigonometric-functions/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-trigonometric-functions/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/@csstools/postcss-trigonometric-functions/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/@csstools/postcss-unset-value": {
+      "version": "3.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@csstools/utilities": {
+      "version": "1.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "../../node_modules/@elastic/ecs-helpers": {
+      "version": "2.1.1",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/@elastic/ecs-pino-format": {
+      "version": "1.5.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@elastic/ecs-helpers": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "../../node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "../../node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "../../node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "../../node_modules/@ethereumjs/rlp": {
+      "version": "4.0.1",
+      "license": "MPL-2.0",
+      "bin": {
+        "rlp": "bin/rlp"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "../../node_modules/@extism/extism": {
+      "version": "1.0.3",
+      "license": "BSD-3-Clause"
+    },
+    "../../node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "../../node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "../../node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "../../node_modules/@iden3/bigarray": {
+      "version": "0.0.2",
+      "license": "GPL-3.0"
+    },
+    "../../node_modules/@iden3/binfileutils": {
+      "version": "0.0.12",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "fastfile": "0.0.20",
+        "ffjavascript": "^0.3.0"
+      }
+    },
+    "../../node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "../../node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "../../node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "../../node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "../../node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.12",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "../../node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "../../node_modules/@jridgewell/source-map": {
+      "version": "0.3.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "../../node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.4",
+      "license": "MIT"
+    },
+    "../../node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.29",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "../../node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "../../node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "../../node_modules/@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "../../node_modules/@jsonjoy.com/buffers": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "../../node_modules/@jsonjoy.com/codegen": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "../../node_modules/@jsonjoy.com/json-pack": {
+      "version": "1.10.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "^1.1.2",
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/json-pointer": "^1.0.1",
+        "@jsonjoy.com/util": "^1.9.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "../../node_modules/@jsonjoy.com/json-pointer": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "../../node_modules/@jsonjoy.com/util": {
+      "version": "1.9.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "../../node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
+      "version": "5.1.1-v1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-scope": "5.1.1"
+      }
+    },
+    "../../node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "../../node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/estraverse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../node_modules/@npmcli/agent": {
+      "version": "4.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "11.3.2",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "../../node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.7.4",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "../../node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "../../node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "../../node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.30.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "../../node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "../../node_modules/@parcel/watcher": {
+      "version": "2.5.1",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.1",
+        "@parcel/watcher-darwin-arm64": "2.5.1",
+        "@parcel/watcher-darwin-x64": "2.5.1",
+        "@parcel/watcher-freebsd-x64": "2.5.1",
+        "@parcel/watcher-linux-arm-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm-musl": "2.5.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm64-musl": "2.5.1",
+        "@parcel/watcher-linux-x64-glibc": "2.5.1",
+        "@parcel/watcher-linux-x64-musl": "2.5.1",
+        "@parcel/watcher-win32-arm64": "2.5.1",
+        "@parcel/watcher-win32-ia32": "2.5.1",
+        "@parcel/watcher-win32-x64": "2.5.1"
+      }
+    },
+    "../../node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.1",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "../../node_modules/@peculiar/webcrypto": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "../../node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "../../node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "license": "MIT"
+    },
+    "../../node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "../../node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "../../node_modules/@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.5.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-html": "^0.0.9",
+        "core-js-pure": "^3.23.3",
+        "error-stack-parser": "^2.0.6",
+        "html-entities": "^2.1.0",
+        "loader-utils": "^2.0.4",
+        "schema-utils": "^4.2.0",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "@types/webpack": "4.x || 5.x",
+        "react-refresh": ">=0.10.0 <1.0.0",
+        "sockjs-client": "^1.4.0",
+        "type-fest": ">=0.17.0 <5.0.0",
+        "webpack": ">=4.43.0 <6.0.0",
+        "webpack-dev-server": "3.x || 4.x || 5.x",
+        "webpack-hot-middleware": "2.x",
+        "webpack-plugin-serve": "0.x || 1.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        },
+        "sockjs-client": {
+          "optional": true
+        },
+        "type-fest": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        },
+        "webpack-hot-middleware": {
+          "optional": true
+        },
+        "webpack-plugin-serve": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@reclaimprotocol/attestor-core": {
+      "version": "5.0.5",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.11.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/webcrypto": "^1.5.0",
+        "@peculiar/x509": "^1.14.3",
+        "@reclaimprotocol/tls": "github:reclaimprotocol/tls",
+        "@reclaimprotocol/zk-symmetric-crypto": "^5.1.3",
+        "ajv": "^8.18.0",
+        "bs58": "^6.0.0",
+        "canonicalize": "^2.1.0",
+        "cbor-x": "^1.6.4",
+        "cose-js": "^0.9.0",
+        "dotenv": "^16.6.1",
+        "elastic-apm-node": "^4.15.0",
+        "esprima-next": "^5.8.4",
+        "ethers": "^6.16.0",
+        "https-proxy-agent": "^7.0.6",
+        "ip-address": "^10.2.0",
+        "ip-cidr": "^3.1.0",
+        "jsonpath-plus": "^10.4.0",
+        "koffi": "^2.15.2",
+        "p-queue": "^8.1.1",
+        "parse5": "^8.0.0",
+        "parse5-htmlparser2-tree-adapter": "^8.0.0",
+        "pino": "^9.14.0",
+        "re2": "^1.23.3",
+        "serve-static": "^1.16.3",
+        "snarkjs": "^0.7.6",
+        "ws": "^8.20.0",
+        "xpath": "^0.0.34"
+      }
+    },
+    "../../node_modules/@reclaimprotocol/attestor-core/node_modules/debug": {
+      "version": "2.6.9",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "../../node_modules/@reclaimprotocol/attestor-core/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/@reclaimprotocol/attestor-core/node_modules/http-errors": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "../../node_modules/@reclaimprotocol/attestor-core/node_modules/ip-address": {
+      "version": "10.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "../../node_modules/@reclaimprotocol/attestor-core/node_modules/send": {
+      "version": "0.19.2",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/@reclaimprotocol/attestor-core/node_modules/serve-static": {
+      "version": "1.16.3",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/@reclaimprotocol/attestor-core/node_modules/statuses": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/@reclaimprotocol/tls": {
+      "version": "0.0.9",
+      "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
+      "dependencies": {
+        "@peculiar/asn1-ecc": "^2.3.14",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/x509": "^1.12.3",
+        "@stablelib/chacha20poly1305": "^1.0.1",
+        "micro-rsa-dsa-dh": "^0.1.0"
+      }
+    },
+    "../../node_modules/@reclaimprotocol/zk-symmetric-crypto": {
+      "version": "5.1.3",
+      "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
+      "dependencies": {
+        "js-base64": "^3.7.7"
+      },
+      "peerDependencies": {
+        "@reclaimprotocol/tls": "*",
+        "koffi": "*",
+        "p-queue": "*",
+        "snarkjs": "*"
+      },
+      "peerDependenciesMeta": {
+        "koffi": {
+          "optional": true
+        },
+        "p-queue": {
+          "optional": true
+        },
+        "snarkjs": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../../node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@rushstack/eslint-patch": {
+      "version": "1.12.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@scure/base": {
+      "version": "1.1.9",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/@scure/bip39": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/@stablelib/aead": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/@stablelib/binary": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "../../node_modules/@stablelib/chacha": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "../../node_modules/@stablelib/chacha20poly1305": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/aead": "^1.0.1",
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/chacha": "^1.0.1",
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/poly1305": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "../../node_modules/@stablelib/constant-time": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/@stablelib/int": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/@stablelib/poly1305": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "../../node_modules/@stablelib/wipe": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "../../node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "../../node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "../../node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "../../node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@types/bonjour": {
+      "version": "3.5.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@types/chrome": {
+      "version": "0.0.202",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "../../node_modules/@types/connect": {
+      "version": "3.4.38",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@types/connect-history-api-fallback": {
+      "version": "1.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "../../node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "../../node_modules/@types/estree": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/express": {
+      "version": "4.17.23",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "../../node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "../../node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "../../node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/history": {
+      "version": "4.7.11",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "../../node_modules/@types/html-minifier-terser": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/http-proxy": {
+      "version": "1.17.16",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/json5": {
+      "version": "0.0.29",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/mime": {
+      "version": "1.3.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/node": {
+      "version": "20.19.10",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "../../node_modules/@types/node-forge": {
+      "version": "1.3.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "license": "MIT"
+    },
+    "../../node_modules/@types/qs": {
+      "version": "6.14.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/react": {
+      "version": "18.3.23",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "../../node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "../../node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "../../node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
+    "../../node_modules/@types/redux-logger": {
+      "version": "3.0.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "../../node_modules/@types/redux-logger/node_modules/redux": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/retry": {
+      "version": "0.12.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/semver": {
+      "version": "7.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/send": {
+      "version": "0.17.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@types/serve-index": {
+      "version": "1.9.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "../../node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
+    },
+    "../../node_modules/@types/sockjs": {
+      "version": "0.3.36",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@types/source-list-map": {
+      "version": "0.1.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "license": "MIT"
+    },
+    "../../node_modules/@types/webextension-polyfill": {
+      "version": "0.10.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@types/webpack-sources": {
+      "version": "3.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.7.3"
+      }
+    },
+    "../../node_modules/@types/ws": {
+      "version": "8.5.3",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.62.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/type-utils": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.62.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "../../node_modules/@typescript-eslint/parser": {
+      "version": "5.62.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "../../node_modules/@typescript-eslint/type-utils": {
+      "version": "5.62.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "../../node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+      "version": "11.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "../../node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "../../node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "../../node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "../../node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "../../node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "../../node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "../../node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "../../node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "../../node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "../../node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "../../node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "../../node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "../../node_modules/@webpack-cli/configtest": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "../../node_modules/@webpack-cli/info": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "../../node_modules/@webpack-cli/serve": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "../../node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "../../node_modules/abab": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "../../node_modules/abbrev": {
+      "version": "4.0.0",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/abitype": {
+      "version": "0.7.1",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=4.9.4",
+        "zod": "^3 >=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/abort-controller": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "../../node_modules/accepts": {
+      "version": "1.3.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/acorn": {
+      "version": "8.15.0",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "../../node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "../../node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
+      }
+    },
+    "../../node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "../../node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "../../node_modules/aes-cbc-mac": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "license": "MIT"
+    },
+    "../../node_modules/after-all-results": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/agent-base": {
+      "version": "7.1.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "../../node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "../../node_modules/ajv": {
+      "version": "8.18.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "../../node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "../../node_modules/ansi-html": {
+      "version": "0.0.9",
+      "dev": true,
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
+      }
+    },
+    "../../node_modules/ansi-html-community": {
+      "version": "0.0.8",
+      "dev": true,
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
+      }
+    },
+    "../../node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "../../node_modules/any-promise": {
+      "version": "1.3.0",
+      "license": "MIT"
+    },
+    "../../node_modules/anymatch": {
+      "version": "3.1.3",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../node_modules/arg": {
+      "version": "5.0.2",
+      "license": "MIT"
+    },
+    "../../node_modules/argparse": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "../../node_modules/aria-query": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/array-flatten": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/array-includes": {
+      "version": "3.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/array-union": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/array-uniq": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/asn1": {
+      "version": "0.2.6",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "../../node_modules/asn1.js": {
+      "version": "4.10.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "../../node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/asn1js": {
+      "version": "3.0.6",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "../../node_modules/assert": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
+    "../../node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/async": {
+      "version": "3.2.6",
+      "license": "MIT"
+    },
+    "../../node_modules/async-function": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/async-value": {
+      "version": "1.2.2",
+      "license": "MIT"
+    },
+    "../../node_modules/async-value-promise": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "async-value": "^1.2.2"
+      }
+    },
+    "../../node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "../../node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "../../node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/axe-core": {
+      "version": "4.10.3",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/axobject-query": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/babel-eslint": {
+      "version": "10.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.12.1"
+      }
+    },
+    "../../node_modules/babel-loader": {
+      "version": "9.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-cache-dir": "^4.0.0",
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0",
+        "webpack": ">=5"
+      }
+    },
+    "../../node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "../../node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/babel-plugin-macros/node_modules/yaml": {
+      "version": "1.10.2",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.14",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.7",
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "../../node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.13.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.5",
+        "core-js-compat": "^3.43.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "../../node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "../../node_modules/babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.24",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/babel-preset-react-app": {
+      "version": "10.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.16.0",
+        "@babel/plugin-proposal-class-properties": "^7.16.0",
+        "@babel/plugin-proposal-decorators": "^7.16.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.0",
+        "@babel/plugin-proposal-numeric-separator": "^7.16.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.16.0",
+        "@babel/plugin-proposal-private-methods": "^7.16.0",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
+        "@babel/plugin-transform-flow-strip-types": "^7.16.0",
+        "@babel/plugin-transform-react-display-name": "^7.16.0",
+        "@babel/plugin-transform-runtime": "^7.16.4",
+        "@babel/preset-env": "^7.16.4",
+        "@babel/preset-react": "^7.16.0",
+        "@babel/preset-typescript": "^7.16.0",
+        "@babel/runtime": "^7.16.3",
+        "babel-plugin-macros": "^3.1.0",
+        "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
+      }
+    },
+    "../../node_modules/babel-preset-react-app/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../node_modules/balanced-match": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "../../node_modules/base-x": {
+      "version": "5.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../../node_modules/basic-auth": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "license": "MIT"
+    },
+    "../../node_modules/batch": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/bfj": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.7.2",
+        "check-types": "^11.2.3",
+        "hoopy": "^0.1.4",
+        "jsonpath": "^1.1.1",
+        "tryer": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "../../node_modules/big.js": {
+      "version": "5.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "../../node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "../../node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/binary-search": {
+      "version": "1.3.6",
+      "license": "CC0-1.0"
+    },
+    "../../node_modules/bluebird": {
+      "version": "3.7.2",
+      "license": "MIT"
+    },
+    "../../node_modules/bn.js": {
+      "version": "5.2.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/body-parser": {
+      "version": "1.20.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "../../node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "../../node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/body-parser/node_modules/qs": {
+      "version": "6.13.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/bonjour-service": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.5"
+      }
+    },
+    "../../node_modules/boolbase": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "../../node_modules/braces": {
+      "version": "3.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/breadth-filter": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "object.entries": "^1.0.4"
+      }
+    },
+    "../../node_modules/brorand": {
+      "version": "1.1.0",
+      "license": "MIT"
+    },
+    "../../node_modules/browser-resolve": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.17.0"
+      }
+    },
+    "../../node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "../../node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "../../node_modules/browserify-des": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "../../node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "../../node_modules/browserify-sign": {
+      "version": "4.2.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.5",
+        "hash-base": "~3.0",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.7",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "../../node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "../../node_modules/browserslist": {
+      "version": "4.25.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001733",
+        "electron-to-chromium": "^1.5.199",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "../../node_modules/bs58": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "../../node_modules/buffer": {
+      "version": "6.0.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "../../node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "../../node_modules/buffer-from": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/bundle-name": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/bytes": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/cacache": {
+      "version": "20.0.4",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/cacache/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../../node_modules/cacache/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../../node_modules/cacache/node_modules/glob": {
+      "version": "13.0.6",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/cacache/node_modules/lru-cache": {
+      "version": "11.3.2",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "../../node_modules/cacache/node_modules/minimatch": {
+      "version": "10.2.5",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/cacache/node_modules/p-map": {
+      "version": "7.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/cacache/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/call-bind": {
+      "version": "1.0.8",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/call-bound": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/callsites": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/camel-case": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "../../node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/caniuse-lite": {
+      "version": "1.0.30001734",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "../../node_modules/canonicalize": {
+      "version": "2.1.0",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "../../node_modules/cbor": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "../../node_modules/cbor-extract": {
+      "version": "2.2.2",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.1.1"
+      },
+      "bin": {
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-win32-x64": "2.2.2"
+      }
+    },
+    "../../node_modules/cbor-x": {
+      "version": "1.6.4",
+      "license": "MIT",
+      "optionalDependencies": {
+        "cbor-extract": "^2.2.2"
+      }
+    },
+    "../../node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "../../node_modules/check-types": {
+      "version": "11.2.3",
+      "license": "MIT"
+    },
+    "../../node_modules/child_process": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "../../node_modules/chokidar": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/chownr": {
+      "version": "3.0.0",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../../node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "../../node_modules/cipher-base": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "../../node_modules/circom_runtime": {
+      "version": "0.1.28",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ffjavascript": "0.3.1"
+      },
+      "bin": {
+        "calcwit": "calcwit.js"
+      }
+    },
+    "../../node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "license": "MIT"
+    },
+    "../../node_modules/clean-css": {
+      "version": "5.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "../../node_modules/clean-css/node_modules/source-map": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/clean-webpack-plugin": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "del": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "webpack": ">=4.0.0 <6.0.0"
+      }
+    },
+    "../../node_modules/clone-deep": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/color-convert": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "../../node_modules/color-name": {
+      "version": "1.1.4",
+      "license": "MIT"
+    },
+    "../../node_modules/colorette": {
+      "version": "2.0.20",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/colors": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "../../node_modules/commander": {
+      "version": "10.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "../../node_modules/common-path-prefix": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/compressible": {
+      "version": "2.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/compression": {
+      "version": "1.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "../../node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/confusing-browser-globals": {
+      "version": "1.0.11",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/connect-history-api-fallback": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "../../node_modules/console-browserify": {
+      "version": "1.2.0",
+      "dev": true
+    },
+    "../../node_modules/console-log-level": {
+      "version": "1.4.1",
+      "license": "MIT"
+    },
+    "../../node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/content-disposition": {
+      "version": "0.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/content-type": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/cookie": {
+      "version": "0.7.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/copy-webpack-plugin": {
+      "version": "11.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.1",
+        "globby": "^13.1.1",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "../../node_modules/core-js-compat": {
+      "version": "3.45.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.25.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "../../node_modules/core-js-pure": {
+      "version": "3.45.0",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "../../node_modules/core-util-is": {
+      "version": "1.0.3",
+      "license": "MIT"
+    },
+    "../../node_modules/cose-js": {
+      "version": "0.9.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aes-cbc-mac": "^1.0.1",
+        "any-promise": "^1.3.0",
+        "cbor": "^8.1.0",
+        "elliptic": "^6.4.0",
+        "node-hkdf-sync": "^1.0.0",
+        "node-rsa": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "../../node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/crc-32": {
+      "version": "1.2.2",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "../../node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "../../node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/create-hash": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "../../node_modules/create-hmac": {
+      "version": "1.1.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "../../node_modules/create-require": {
+      "version": "1.1.1",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "../../node_modules/cross-env": {
+      "version": "7.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "../../node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "../../node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../node_modules/crypto-browserify": {
+      "version": "3.12.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/css-blank-pseudo": {
+      "version": "6.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/css-blank-pseudo/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/css-has-pseudo": {
+      "version": "6.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/selector-specificity": "^3.1.1",
+        "postcss-selector-parser": "^6.0.13",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/css-has-pseudo/node_modules/@csstools/selector-specificity": {
+      "version": "3.1.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "../../node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/css-loader": {
+      "version": "6.11.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.33",
+        "postcss-modules-extract-imports": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.5",
+        "postcss-modules-scope": "^3.2.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/css-loader/node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/css-prefers-color-scheme": {
+      "version": "9.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/css-select": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "../../node_modules/css-select/node_modules/domhandler": {
+      "version": "4.3.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "../../node_modules/css-what": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "../../node_modules/cssdb": {
+      "version": "8.3.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "../../node_modules/cssesc": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/csstype": {
+      "version": "3.1.3",
+      "license": "MIT"
+    },
+    "../../node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "../../node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "../../node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/debounce": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/debug": {
+      "version": "4.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/deep-diff": {
+      "version": "0.3.8",
+      "license": "MIT"
+    },
+    "../../node_modules/deep-is": {
+      "version": "0.1.4",
+      "license": "MIT"
+    },
+    "../../node_modules/default-browser": {
+      "version": "5.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/define-data-property": {
+      "version": "1.1.4",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/define-properties": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/del": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/del/node_modules/array-union": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/del/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/del/node_modules/globby": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/del/node_modules/globby/node_modules/pify": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/depd": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/des.js": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "../../node_modules/destroy": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "../../node_modules/detect-libc": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "../../node_modules/detect-node": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/didyoumean": {
+      "version": "1.2.2",
+      "license": "Apache-2.0"
+    },
+    "../../node_modules/diff": {
+      "version": "4.0.2",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "../../node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "../../node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/dir-glob": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/dlv": {
+      "version": "1.1.3",
+      "license": "MIT"
+    },
+    "../../node_modules/dns-packet": {
+      "version": "5.6.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/doctrine": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "../../node_modules/dom-converter": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "utila": "~0.4"
+      }
+    },
+    "../../node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "../../node_modules/dom-serializer/node_modules/domhandler": {
+      "version": "4.3.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "../../node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "../../node_modules/domain-browser": {
+      "version": "4.22.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "../../node_modules/domelementtype": {
+      "version": "2.3.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "../../node_modules/domhandler": {
+      "version": "5.0.3",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "../../node_modules/domutils": {
+      "version": "2.8.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "../../node_modules/domutils/node_modules/domhandler": {
+      "version": "4.3.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "../../node_modules/dot-case": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "../../node_modules/dotenv": {
+      "version": "16.6.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "../../node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/duplexer": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "license": "MIT"
+    },
+    "../../node_modules/ee-first": {
+      "version": "1.1.1",
+      "license": "MIT"
+    },
+    "../../node_modules/ejs": {
+      "version": "3.1.10",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/elastic-apm-node": {
+      "version": "4.15.0",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@elastic/ecs-pino-format": "^1.5.0",
+        "@opentelemetry/api": "^1.4.1",
+        "@opentelemetry/core": "^1.11.0",
+        "@opentelemetry/sdk-metrics": "^1.12.0",
+        "after-all-results": "^2.0.0",
+        "agentkeepalive": "^4.2.1",
+        "async-value-promise": "^1.1.1",
+        "basic-auth": "^2.0.1",
+        "breadth-filter": "^2.0.0",
+        "cookie": "^0.7.1",
+        "core-util-is": "^1.0.2",
+        "end-of-stream": "^1.4.4",
+        "error-callsites": "^2.0.4",
+        "error-stack-parser": "^2.0.6",
+        "escape-string-regexp": "^4.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "fast-stream-to-buffer": "^1.0.0",
+        "http-headers": "^3.0.2",
+        "import-in-the-middle": "1.14.4",
+        "json-bigint": "^1.0.0",
+        "lru-cache": "10.2.0",
+        "measured-reporting": "^1.51.1",
+        "module-details-from-path": "^1.0.3",
+        "monitor-event-loop-delay": "^1.0.0",
+        "object-filter-sequence": "^1.0.0",
+        "object-identity-map": "^1.0.2",
+        "original-url": "^1.2.3",
+        "pino": "^8.15.0",
+        "readable-stream": "^3.6.2",
+        "relative-microtime": "^2.0.0",
+        "require-in-the-middle": "^8.0.0",
+        "semver": "^7.5.4",
+        "shallow-clone-shim": "^2.0.0",
+        "source-map": "^0.8.0-beta.0",
+        "sql-summary": "^1.0.1",
+        "stream-chopper": "^3.0.1",
+        "unicode-byte-truncate": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14.17.0"
+      }
+    },
+    "../../node_modules/elastic-apm-node/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "license": "ISC",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "../../node_modules/elastic-apm-node/node_modules/pino": {
+      "version": "8.21.0",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "../../node_modules/elastic-apm-node/node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "../../node_modules/elastic-apm-node/node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "../../node_modules/elastic-apm-node/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "license": "MIT"
+    },
+    "../../node_modules/elastic-apm-node/node_modules/process-warning": {
+      "version": "3.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/elastic-apm-node/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/elastic-apm-node/node_modules/semver": {
+      "version": "7.7.4",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/elastic-apm-node/node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "../../node_modules/elastic-apm-node/node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../node_modules/elastic-apm-node/node_modules/thread-stream": {
+      "version": "2.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "../../node_modules/electron-to-chromium": {
+      "version": "1.5.200",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/elliptic": {
+      "version": "6.6.1",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "../../node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.2",
+      "license": "MIT"
+    },
+    "../../node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "license": "MIT"
+    },
+    "../../node_modules/emojis-list": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "../../node_modules/encodeurl": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "../../node_modules/enhanced-resolve": {
+      "version": "5.18.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "../../node_modules/entities": {
+      "version": "4.5.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "../../node_modules/env-paths": {
+      "version": "2.2.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/envinfo": {
+      "version": "7.14.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "envinfo": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/error-callsites": {
+      "version": "2.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.x"
+      }
+    },
+    "../../node_modules/error-ex": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "../../node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "../../node_modules/es-abstract": {
+      "version": "1.24.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/es-define-property": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/es-errors": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/es-iterator-helpers": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.3",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.6",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.4",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/escalade": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/escape-html": {
+      "version": "1.0.3",
+      "license": "MIT"
+    },
+    "../../node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/escodegen": {
+      "version": "1.14.3",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "../../node_modules/escodegen/node_modules/esprima": {
+      "version": "4.0.1",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/escodegen/node_modules/estraverse": {
+      "version": "4.3.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../node_modules/escodegen/node_modules/levn": {
+      "version": "0.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/escodegen/node_modules/optionator": {
+      "version": "0.8.3",
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/escodegen/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/escodegen/node_modules/type-check": {
+      "version": "0.3.2",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/eslint": {
+      "version": "8.57.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "../../node_modules/eslint-config-react-app": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.16.0",
+        "@babel/eslint-parser": "^7.16.3",
+        "@rushstack/eslint-patch": "^1.1.0",
+        "@typescript-eslint/eslint-plugin": "^5.5.0",
+        "@typescript-eslint/parser": "^5.5.0",
+        "babel-preset-react-app": "^10.0.1",
+        "confusing-browser-globals": "^1.0.11",
+        "eslint-plugin-flowtype": "^8.0.3",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-jest": "^25.3.0",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.27.1",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-testing-library": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0"
+      }
+    },
+    "../../node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "../../node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "../../node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "../../node_modules/eslint-plugin-flowtype": {
+      "version": "8.0.3",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "string-natural-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@babel/plugin-syntax-flow": "^7.14.5",
+        "@babel/plugin-transform-react-jsx": "^7.14.9",
+        "eslint": "^8.1.0"
+      }
+    },
+    "../../node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "../../node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "../../node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/eslint-plugin-jest": {
+      "version": "25.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^4.0.0 || ^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "../../node_modules/eslint-plugin-prettier": {
+      "version": "5.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "../../node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "../../node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/eslint-plugin-testing-library": {
+      "version": "5.11.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.58.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": "^7.5.0 || ^8.0.0"
+      }
+    },
+    "../../node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "../../node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/espree": {
+      "version": "9.6.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../node_modules/esprima": {
+      "version": "1.2.2",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "../../node_modules/esprima-next": {
+      "version": "5.8.4",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "../../node_modules/esquery": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "../../node_modules/esrecurse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../node_modules/estraverse": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../node_modules/esutils": {
+      "version": "2.0.3",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/etag": {
+      "version": "1.8.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/ethereum-cryptography": {
+      "version": "2.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
+      }
+    },
+    "../../node_modules/ethereum-cryptography/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/ethers": {
+      "version": "6.16.0",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../../node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "../../node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "license": "0BSD"
+    },
+    "../../node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "license": "MIT"
+    },
+    "../../node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/events": {
+      "version": "3.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "../../node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "../../node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "license": "Apache-2.0"
+    },
+    "../../node_modules/express": {
+      "version": "4.21.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "../../node_modules/express/node_modules/cookie": {
+      "version": "0.7.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "../../node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/express/node_modules/qs": {
+      "version": "6.13.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/eyes": {
+      "version": "0.1.8",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
+    "../../node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "license": "MIT"
+    },
+    "../../node_modules/fast-diff": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "../../node_modules/fast-glob": {
+      "version": "3.3.3",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "../../node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "license": "MIT"
+    },
+    "../../node_modules/fast-redact": {
+      "version": "3.5.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "license": "MIT"
+    },
+    "../../node_modules/fast-stream-to-buffer": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1"
+      }
+    },
+    "../../node_modules/fast-uri": {
+      "version": "3.0.6",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "../../node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "../../node_modules/fastfile": {
+      "version": "0.0.20",
+      "license": "GPL-3.0"
+    },
+    "../../node_modules/fastq": {
+      "version": "1.19.1",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "../../node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "../../node_modules/ffjavascript": {
+      "version": "0.3.1",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.2",
+        "web-worker": "1.2.0"
+      }
+    },
+    "../../node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "../../node_modules/file-loader": {
+      "version": "6.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "../../node_modules/file-loader/node_modules/ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "../../node_modules/file-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "../../node_modules/file-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/file-loader/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "../../node_modules/filelist": {
+      "version": "1.0.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "../../node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "../../node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/fill-range": {
+      "version": "7.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/finalhandler": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "../../node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/find-cache-dir": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "common-path-prefix": "^3.0.0",
+        "pkg-dir": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/flat": {
+      "version": "5.0.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "../../node_modules/flat-cache": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "../../node_modules/flat-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/flatted": {
+      "version": "3.3.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/for-each": {
+      "version": "0.3.5",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/foreground-child": {
+      "version": "3.3.1",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/forwarded": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "../../node_modules/fraction.js": {
+      "version": "4.3.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "../../node_modules/fresh": {
+      "version": "0.5.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/fs-extra": {
+      "version": "11.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "../../node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "../../node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/fsevents": {
+      "version": "2.3.3",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "../../node_modules/function-bind": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../../node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/get-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/glob": {
+      "version": "10.4.5",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/glob-parent": {
+      "version": "6.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "../../node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "../../node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "../../node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/globals": {
+      "version": "13.24.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/globalthis": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/globby": {
+      "version": "13.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/gopd": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "license": "ISC"
+    },
+    "../../node_modules/graphemer": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/gzip-size": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/handle-thing": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/has-bigints": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/has-proto": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/has-symbols": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/hash-base": {
+      "version": "3.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "../../node_modules/hash.js": {
+      "version": "1.1.7",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "../../node_modules/hasown": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/he": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "../../node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "../../node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "../../node_modules/hoopy": {
+      "version": "0.1.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "../../node_modules/hpack.js": {
+      "version": "2.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      }
+    },
+    "../../node_modules/html-entities": {
+      "version": "2.6.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../../node_modules/html-escaper": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/html-loader": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "html-minifier-terser": "^7.0.0",
+        "parse5": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "../../node_modules/html-loader/node_modules/entities": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "../../node_modules/html-loader/node_modules/parse5": {
+      "version": "7.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "../../node_modules/html-minifier-terser": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "~5.3.2",
+        "commander": "^10.0.0",
+        "entities": "^4.4.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.15.1"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "../../node_modules/html-webpack-plugin": {
+      "version": "5.6.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/html-minifier-terser": "^6.0.0",
+        "html-minifier-terser": "^6.0.2",
+        "lodash": "^4.17.21",
+        "pretty-error": "^4.0.0",
+        "tapable": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/html-webpack-plugin"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
+        "webpack": "^5.20.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/html-webpack-plugin/node_modules/commander": {
+      "version": "8.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "../../node_modules/html-webpack-plugin/node_modules/html-minifier-terser": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "^5.2.2",
+        "commander": "^8.3.0",
+        "he": "^1.2.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.10.0"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "../../node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
+    "../../node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "4.3.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "../../node_modules/htmlparser2/node_modules/entities": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "../../node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "license": "BSD-2-Clause"
+    },
+    "../../node_modules/http-deceiver": {
+      "version": "1.2.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/http-errors": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/http-headers": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "next-line": "^1.1.0"
+      }
+    },
+    "../../node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/http-proxy": {
+      "version": "1.18.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "../../node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "../../node_modules/http-proxy-middleware": {
+      "version": "2.0.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/http-proxy/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/https-browserify": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "../../node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "../../node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      }
+    },
+    "../../node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/icss-utils": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "../../node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "../../node_modules/ignore": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "../../node_modules/immutable": {
+      "version": "5.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/import-fresh": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/import-in-the-middle": {
+      "version": "1.14.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "../../node_modules/import-local": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/import-local/node_modules/find-up": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/import-local/node_modules/locate-path": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/import-local/node_modules/p-limit": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/import-local/node_modules/p-locate": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/import-local/node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "../../node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "../../node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC"
+    },
+    "../../node_modules/install-artifact-from-github": {
+      "version": "1.4.0",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "install-from-cache": "bin/install-from-cache.js",
+        "save-to-github-cache": "bin/save-to-github-cache.js"
+      }
+    },
+    "../../node_modules/internal-slot": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/interpret": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "../../node_modules/ip-address": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../node_modules/ip-cidr": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^7.1.0",
+        "jsbn": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "../../node_modules/ipaddr.js": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../node_modules/is-arguments": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/is-async-function": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-bigint": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-callable": {
+      "version": "1.2.7",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-core-module": {
+      "version": "2.16.1",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-data-view": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-date-object": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-docker": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/is-extglob": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-finite": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-glob": {
+      "version": "4.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/is-integer": {
+      "version": "1.0.7",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "../../node_modules/is-map": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-nan": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-network-error": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/is-number": {
+      "version": "7.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "../../node_modules/is-number-object": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-path-cwd": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/is-path-in-cwd": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-path-inside": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/is-path-in-cwd/node_modules/is-path-inside": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-is-inside": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/is-regex": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-set": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-string": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-symbol": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-weakref": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-weakset": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/is-wsl": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/isarray": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/isexe": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
+    "../../node_modules/isobject": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/isomorphic-timers-promises": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "../../node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/jackspeak": {
+      "version": "3.4.3",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "../../node_modules/jake": {
+      "version": "10.9.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/jest-worker": {
+      "version": "27.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "../../node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "../../node_modules/jiti": {
+      "version": "1.21.7",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "../../node_modules/js-base64": {
+      "version": "3.7.8",
+      "license": "BSD-3-Clause"
+    },
+    "../../node_modules/js-tokens": {
+      "version": "4.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/js-yaml": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "../../node_modules/jsbn": {
+      "version": "1.1.0",
+      "license": "MIT"
+    },
+    "../../node_modules/jsep": {
+      "version": "1.4.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "../../node_modules/jsesc": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/json-bigint": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "../../node_modules/json-buffer": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/json5": {
+      "version": "2.2.3",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "../../node_modules/jsonpath": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.12.1"
+      }
+    },
+    "../../node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "../../node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../node_modules/keyv": {
+      "version": "4.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "../../node_modules/kind-of": {
+      "version": "6.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/koffi": {
+      "version": "2.15.5",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "../../node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "../../node_modules/language-tags": {
+      "version": "1.0.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "../../node_modules/launch-editor": {
+      "version": "2.11.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.3"
+      }
+    },
+    "../../node_modules/levn": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/lilconfig": {
+      "version": "3.1.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "../../node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "license": "MIT"
+    },
+    "../../node_modules/loader-runner": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "../../node_modules/loader-utils": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "../../node_modules/locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/lodash": {
+      "version": "4.17.21",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "license": "MIT"
+    },
+    "../../node_modules/logplease": {
+      "version": "1.2.15",
+      "license": "MIT"
+    },
+    "../../node_modules/loose-envify": {
+      "version": "1.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "../../node_modules/lower-case": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "../../node_modules/lru-cache": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "../../node_modules/make-error": {
+      "version": "1.3.6",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
+    "../../node_modules/make-fetch-happen": {
+      "version": "15.0.5",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/mapcap": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/md5.js": {
+      "version": "1.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "../../node_modules/measured-core": {
+      "version": "1.51.1",
+      "license": "MIT",
+      "dependencies": {
+        "binary-search": "^1.3.3",
+        "optional-js": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 5.12"
+      }
+    },
+    "../../node_modules/measured-reporting": {
+      "version": "1.51.1",
+      "license": "MIT",
+      "dependencies": {
+        "console-log-level": "^1.4.1",
+        "mapcap": "^1.0.0",
+        "measured-core": "^1.51.1",
+        "optional-js": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 5.12"
+      }
+    },
+    "../../node_modules/media-typer": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/memfs": {
+      "version": "4.36.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/json-pack": "^1.0.3",
+        "@jsonjoy.com/util": "^1.3.0",
+        "tree-dump": "^1.0.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      }
+    },
+    "../../node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/merge-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/merge2": {
+      "version": "1.4.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../node_modules/methods": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/micro-rsa-dsa-dh": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/micro-rsa-dsa-dh/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/micromatch": {
+      "version": "4.0.8",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "../../node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "../../node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/mime": {
+      "version": "1.6.0",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/mime-db": {
+      "version": "1.52.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/mime-types": {
+      "version": "2.1.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "license": "ISC"
+    },
+    "../../node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "../../node_modules/minimist": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/minipass": {
+      "version": "7.1.3",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "../../node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "../../node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "../../node_modules/minipass-fetch/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "../../node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "license": "ISC"
+    },
+    "../../node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "license": "ISC"
+    },
+    "../../node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/minizlib": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "../../node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "license": "MIT"
+    },
+    "../../node_modules/monitor-event-loop-delay": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/mrmime": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
+    },
+    "../../node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
+    "../../node_modules/mz": {
+      "version": "2.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "../../node_modules/nan": {
+      "version": "2.26.2",
+      "license": "MIT"
+    },
+    "../../node_modules/nanoid": {
+      "version": "3.3.11",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "../../node_modules/natural-compare": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/negotiator": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/neo-async": {
+      "version": "2.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/next-line": {
+      "version": "1.1.0",
+      "license": "MIT"
+    },
+    "../../node_modules/no-case": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "../../node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "../../node_modules/node-fetch": {
+      "version": "2.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "license": "MIT"
+    },
+    "../../node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "license": "BSD-2-Clause"
+    },
+    "../../node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "../../node_modules/node-forge": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "../../node_modules/node-gyp": {
+      "version": "12.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "../../node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "../../node_modules/node-gyp/node_modules/semver": {
+      "version": "7.7.4",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/node-hkdf-sync": {
+      "version": "1.0.0",
+      "dependencies": {
+        "vows": "0.5.13"
+      },
+      "engines": {
+        "node": ">= 0.6.5"
+      }
+    },
+    "../../node_modules/node-polyfill-webpack-plugin": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-stdlib-browser": "^1.3.0",
+        "type-fest": "^4.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "webpack": ">=5"
+      }
+    },
+    "../../node_modules/node-polyfill-webpack-plugin/node_modules/type-fest": {
+      "version": "4.41.0",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/node-releases": {
+      "version": "2.0.19",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/node-rsa": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "^0.2.4"
+      }
+    },
+    "../../node_modules/node-stdlib-browser": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert": "^2.0.0",
+        "browser-resolve": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^5.7.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "create-require": "^1.1.1",
+        "crypto-browserify": "^3.12.1",
+        "domain-browser": "4.22.0",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "isomorphic-timers-promises": "^1.0.1",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "^1.0.1",
+        "pkg-dir": "^5.0.0",
+        "process": "^0.11.10",
+        "punycode": "^1.4.1",
+        "querystring-es3": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.1",
+        "url": "^0.11.4",
+        "util": "^0.12.4",
+        "vm-browserify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/node-stdlib-browser/node_modules/buffer": {
+      "version": "5.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "../../node_modules/node-stdlib-browser/node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/node-stdlib-browser/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/nofilter": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "../../node_modules/nopt": {
+      "version": "9.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/normalize-path": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/normalize-range": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/nth-check": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "../../node_modules/object-assign": {
+      "version": "4.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/object-filter-sequence": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/object-hash": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/object-identity-map": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "object.entries": "^1.1.0"
+      }
+    },
+    "../../node_modules/object-inspect": {
+      "version": "1.13.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/object-is": {
+      "version": "1.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/object-keys": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/object.assign": {
+      "version": "4.1.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/object.entries": {
+      "version": "1.1.9",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/object.groupby": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/object.values": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/obuf": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../../node_modules/on-finished": {
+      "version": "2.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/on-headers": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "../../node_modules/open": {
+      "version": "10.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/opener": {
+      "version": "1.5.2",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "../../node_modules/optional-js": {
+      "version": "2.3.0",
+      "license": "MIT"
+    },
+    "../../node_modules/optionator": {
+      "version": "0.9.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/original-url": {
+      "version": "1.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded-parse": "^2.1.0"
+      }
+    },
+    "../../node_modules/os-browserify": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/own-keys": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/p-map": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/p-queue": {
+      "version": "8.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/p-retry": {
+      "version": "6.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "../../node_modules/p-timeout": {
+      "version": "6.1.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/p-try": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "license": "BlueOak-1.0.0"
+    },
+    "../../node_modules/pako": {
+      "version": "1.0.11",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "../../node_modules/param-case": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "../../node_modules/parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/parse-asn1": {
+      "version": "5.1.7",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "hash-base": "~3.0",
+        "pbkdf2": "^3.1.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "../../node_modules/parse-json": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/parse5": {
+      "version": "8.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "../../node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "8.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "../../node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "../../node_modules/parseurl": {
+      "version": "1.3.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/pascal-case": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "../../node_modules/path-browserify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "../../node_modules/path-key": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/path-parse": {
+      "version": "1.0.7",
+      "license": "MIT"
+    },
+    "../../node_modules/path-scurry": {
+      "version": "1.11.1",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "license": "ISC"
+    },
+    "../../node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/path-type": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/pbkdf2": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "~1.1.3",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "=2.0.1",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.11",
+        "to-buffer": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "../../node_modules/pbkdf2/node_modules/create-hash": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "../../node_modules/pbkdf2/node_modules/hash-base": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "../../node_modules/pbkdf2/node_modules/ripemd160": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "../../node_modules/picocolors": {
+      "version": "1.1.1",
+      "license": "ISC"
+    },
+    "../../node_modules/picomatch": {
+      "version": "2.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "../../node_modules/pify": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/pinkie": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/pino": {
+      "version": "9.14.0",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "../../node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "../../node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "license": "MIT"
+    },
+    "../../node_modules/pirates": {
+      "version": "4.0.7",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/pkg-dir": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/pkg-dir/node_modules/find-up": {
+      "version": "6.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "../../node_modules/pkg-dir/node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/postcss": {
+      "version": "8.5.6",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "../../node_modules/postcss-attribute-case-insensitive": {
+      "version": "6.0.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-attribute-case-insensitive/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-clamp": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=7.6.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.6"
+      }
+    },
+    "../../node_modules/postcss-color-functional-notation": {
+      "version": "6.0.14",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^2.0.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-color-functional-notation/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/postcss-color-functional-notation/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-color-functional-notation/node_modules/@csstools/css-color-parser": {
+      "version": "2.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "@csstools/css-calc": "^1.2.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-color-functional-notation/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-color-functional-notation/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/postcss-color-hex-alpha": {
+      "version": "9.0.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/utilities": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-color-rebeccapurple": {
+      "version": "9.0.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/utilities": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-custom-media": {
+      "version": "10.0.8",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/cascade-layer-name-parser": "^1.0.13",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/media-query-list-parser": "^2.1.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-custom-media/node_modules/@csstools/cascade-layer-name-parser": {
+      "version": "1.0.13",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-custom-media/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-custom-media/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/postcss-custom-media/node_modules/@csstools/media-query-list-parser": {
+      "version": "2.1.13",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-custom-properties": {
+      "version": "13.3.12",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/cascade-layer-name-parser": "^1.0.13",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/utilities": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-custom-properties/node_modules/@csstools/cascade-layer-name-parser": {
+      "version": "1.0.13",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-custom-properties/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-custom-properties/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/postcss-custom-selectors": {
+      "version": "7.1.12",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/cascade-layer-name-parser": "^1.0.13",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "postcss-selector-parser": "^6.1.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-custom-selectors/node_modules/@csstools/cascade-layer-name-parser": {
+      "version": "1.0.13",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-custom-selectors/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-custom-selectors/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-dir-pseudo-class": {
+      "version": "8.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-double-position-gradients": {
+      "version": "5.0.7",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-focus-visible": {
+      "version": "9.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-focus-visible/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-focus-within": {
+      "version": "8.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-focus-within/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-font-variant": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "../../node_modules/postcss-gap-properties": {
+      "version": "5.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-image-set-function": {
+      "version": "6.0.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/utilities": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-import": {
+      "version": "15.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "../../node_modules/postcss-js": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "../../node_modules/postcss-lab-function": {
+      "version": "6.0.19",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^2.0.4",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/utilities": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-lab-function/node_modules/@csstools/color-helpers": {
+      "version": "4.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/postcss-lab-function/node_modules/@csstools/css-calc": {
+      "version": "1.2.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-lab-function/node_modules/@csstools/css-color-parser": {
+      "version": "2.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^4.2.1",
+        "@csstools/css-calc": "^1.2.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-lab-function/node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.4.1"
+      }
+    },
+    "../../node_modules/postcss-lab-function/node_modules/@csstools/css-tokenizer": {
+      "version": "2.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "../../node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/postcss-loader": {
+      "version": "7.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cosmiconfig": "^8.3.5",
+        "jiti": "^1.20.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "postcss": "^7.0.0 || ^8.0.1",
+        "webpack": "^5.0.0"
+      }
+    },
+    "../../node_modules/postcss-loader/node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/postcss-logical": {
+      "version": "7.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "../../node_modules/postcss-modules-local-by-default": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "../../node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "../../node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "../../node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "../../node_modules/postcss-nested/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-nesting": {
+      "version": "12.1.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/selector-resolve-nested": "^1.1.0",
+        "@csstools/selector-specificity": "^3.1.1",
+        "postcss-selector-parser": "^6.1.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-nesting/node_modules/@csstools/selector-resolve-nested": {
+      "version": "1.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "../../node_modules/postcss-nesting/node_modules/@csstools/selector-specificity": {
+      "version": "3.1.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "../../node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-opacity-percentage": {
+      "version": "2.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "kofi",
+          "url": "https://ko-fi.com/mrcgrtz"
+        },
+        {
+          "type": "liberapay",
+          "url": "https://liberapay.com/mrcgrtz"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2"
+      }
+    },
+    "../../node_modules/postcss-overflow-shorthand": {
+      "version": "5.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-page-break": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "postcss": "^8"
+      }
+    },
+    "../../node_modules/postcss-place": {
+      "version": "9.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-preset-env": {
+      "version": "9.6.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/postcss-cascade-layers": "^4.0.6",
+        "@csstools/postcss-color-function": "^3.0.19",
+        "@csstools/postcss-color-mix-function": "^2.0.19",
+        "@csstools/postcss-content-alt-text": "^1.0.0",
+        "@csstools/postcss-exponential-functions": "^1.0.9",
+        "@csstools/postcss-font-format-keywords": "^3.0.2",
+        "@csstools/postcss-gamut-mapping": "^1.0.11",
+        "@csstools/postcss-gradients-interpolation-method": "^4.0.20",
+        "@csstools/postcss-hwb-function": "^3.0.18",
+        "@csstools/postcss-ic-unit": "^3.0.7",
+        "@csstools/postcss-initial": "^1.0.1",
+        "@csstools/postcss-is-pseudo-class": "^4.0.8",
+        "@csstools/postcss-light-dark-function": "^1.0.8",
+        "@csstools/postcss-logical-float-and-clear": "^2.0.1",
+        "@csstools/postcss-logical-overflow": "^1.0.1",
+        "@csstools/postcss-logical-overscroll-behavior": "^1.0.1",
+        "@csstools/postcss-logical-resize": "^2.0.1",
+        "@csstools/postcss-logical-viewport-units": "^2.0.11",
+        "@csstools/postcss-media-minmax": "^1.1.8",
+        "@csstools/postcss-media-queries-aspect-ratio-number-values": "^2.0.11",
+        "@csstools/postcss-nested-calc": "^3.0.2",
+        "@csstools/postcss-normalize-display-values": "^3.0.2",
+        "@csstools/postcss-oklab-function": "^3.0.19",
+        "@csstools/postcss-progressive-custom-properties": "^3.3.0",
+        "@csstools/postcss-relative-color-syntax": "^2.0.19",
+        "@csstools/postcss-scope-pseudo-class": "^3.0.1",
+        "@csstools/postcss-stepped-value-functions": "^3.0.10",
+        "@csstools/postcss-text-decoration-shorthand": "^3.0.7",
+        "@csstools/postcss-trigonometric-functions": "^3.0.10",
+        "@csstools/postcss-unset-value": "^3.0.1",
+        "autoprefixer": "^10.4.19",
+        "browserslist": "^4.23.1",
+        "css-blank-pseudo": "^6.0.2",
+        "css-has-pseudo": "^6.0.5",
+        "css-prefers-color-scheme": "^9.0.1",
+        "cssdb": "^8.1.0",
+        "postcss-attribute-case-insensitive": "^6.0.3",
+        "postcss-clamp": "^4.1.0",
+        "postcss-color-functional-notation": "^6.0.14",
+        "postcss-color-hex-alpha": "^9.0.4",
+        "postcss-color-rebeccapurple": "^9.0.3",
+        "postcss-custom-media": "^10.0.8",
+        "postcss-custom-properties": "^13.3.12",
+        "postcss-custom-selectors": "^7.1.12",
+        "postcss-dir-pseudo-class": "^8.0.1",
+        "postcss-double-position-gradients": "^5.0.7",
+        "postcss-focus-visible": "^9.0.1",
+        "postcss-focus-within": "^8.0.1",
+        "postcss-font-variant": "^5.0.0",
+        "postcss-gap-properties": "^5.0.1",
+        "postcss-image-set-function": "^6.0.3",
+        "postcss-lab-function": "^6.0.19",
+        "postcss-logical": "^7.0.1",
+        "postcss-nesting": "^12.1.5",
+        "postcss-opacity-percentage": "^2.0.0",
+        "postcss-overflow-shorthand": "^5.0.1",
+        "postcss-page-break": "^3.0.4",
+        "postcss-place": "^9.0.1",
+        "postcss-pseudo-class-any-link": "^9.0.2",
+        "postcss-replace-overflow-wrap": "^4.0.0",
+        "postcss-selector-not": "^7.0.2"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-pseudo-class-any-link": {
+      "version": "9.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-replace-overflow-wrap": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "postcss": "^8.0.3"
+      }
+    },
+    "../../node_modules/postcss-selector-not": {
+      "version": "7.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "../../node_modules/postcss-selector-not/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-selector-parser": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "license": "MIT"
+    },
+    "../../node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/prettier": {
+      "version": "3.8.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "../../node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "../../node_modules/pretty-error": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.20",
+        "renderkid": "^3.0.0"
+      }
+    },
+    "../../node_modules/proc-log": {
+      "version": "6.1.0",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/process": {
+      "version": "0.11.10",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "../../node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/process-warning": {
+      "version": "5.0.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../../node_modules/prop-types": {
+      "version": "15.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "../../node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "../../node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "../../node_modules/pseudomap": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "../../node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/punycode": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../node_modules/pvutils": {
+      "version": "1.1.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "../../node_modules/qs": {
+      "version": "6.14.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "../../node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../../node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "license": "MIT"
+    },
+    "../../node_modules/r1csfile": {
+      "version": "0.0.48",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@iden3/bigarray": "0.0.2",
+        "@iden3/binfileutils": "0.0.12",
+        "fastfile": "0.0.20",
+        "ffjavascript": "0.3.0"
+      }
+    },
+    "../../node_modules/r1csfile/node_modules/ffjavascript": {
+      "version": "0.3.0",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "wasmbuilder": "0.0.16",
+        "wasmcurves": "0.2.2",
+        "web-worker": "1.2.0"
+      }
+    },
+    "../../node_modules/randombytes": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "../../node_modules/randomfill": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "../../node_modules/range-parser": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/raw-body": {
+      "version": "2.5.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/re2": {
+      "version": "1.24.0",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "install-artifact-from-github": "^1.4.0",
+        "nan": "^2.26.2",
+        "node-gyp": "^12.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
+    },
+    "../../node_modules/react": {
+      "version": "18.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/react-dom": {
+      "version": "18.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "../../node_modules/react-is": {
+      "version": "16.13.1",
+      "license": "MIT"
+    },
+    "../../node_modules/react-redux": {
+      "version": "8.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/react-redux/node_modules/react-is": {
+      "version": "18.3.1",
+      "license": "MIT"
+    },
+    "../../node_modules/react-refresh": {
+      "version": "0.14.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/react-refresh-typescript": {
+      "version": "2.0.10",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react-refresh": "0.10.x || 0.11.x || 0.12.x || 0.13.x || 0.14.x || 0.15.x || 0.16.x || 0.17.x",
+        "typescript": "^4.8 || ^5.0"
+      }
+    },
+    "../../node_modules/react-router": {
+      "version": "6.30.1",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "../../node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "../../node_modules/read-cache": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "../../node_modules/read-cache/node_modules/pify": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/readable-stream": {
+      "version": "2.3.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "../../node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "../../node_modules/readdirp": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/real-require": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "../../node_modules/rechoir": {
+      "version": "0.7.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "../../node_modules/redux": {
+      "version": "4.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "../../node_modules/redux-logger": {
+      "version": "3.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "deep-diff": "^0.3.5"
+      }
+    },
+    "../../node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
+    "../../node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "license": "Apache-2.0"
+    },
+    "../../node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/regenerate": {
+      "version": "1.4.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/regenerate-unicode-properties": {
+      "version": "10.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/regexpu-core": {
+      "version": "6.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.2.0",
+        "regjsgen": "^0.8.0",
+        "regjsparser": "^0.12.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/regjsgen": {
+      "version": "0.8.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/regjsparser": {
+      "version": "0.12.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.0.2"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "../../node_modules/regjsparser/node_modules/jsesc": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/relateurl": {
+      "version": "0.2.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "../../node_modules/relative-microtime": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/renderkid": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "../../node_modules/require-from-string": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "../../node_modules/requires-port": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/resolve": {
+      "version": "1.22.10",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/resolve-from": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/reusify": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/rimraf": {
+      "version": "2.7.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "../../node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../node_modules/ripemd160": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "../../node_modules/run-applescript": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/run-parallel": {
+      "version": "1.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "../../node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../../node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "../../node_modules/sass": {
+      "version": "1.90.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "../../node_modules/sass-loader": {
+      "version": "13.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "neo-async": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "sass": "^1.3.0",
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/scheduler": {
+      "version": "0.23.2",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "../../node_modules/schema-utils": {
+      "version": "4.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "../../node_modules/select-hose": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/selfsigned": {
+      "version": "2.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "../../node_modules/send": {
+      "version": "0.19.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "../../node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "../../node_modules/serve-index": {
+      "version": "1.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/serve-index/node_modules/debug": {
+      "version": "2.6.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "../../node_modules/serve-index/node_modules/depd": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/serve-index/node_modules/http-errors": {
+      "version": "1.6.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/serve-index/node_modules/inherits": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/serve-index/node_modules/ms": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/serve-index/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/serve-index/node_modules/statuses": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/serve-static": {
+      "version": "1.16.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/set-function-length": {
+      "version": "1.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/set-function-name": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/set-proto": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/setimmediate": {
+      "version": "1.0.5",
+      "license": "MIT"
+    },
+    "../../node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "license": "ISC"
+    },
+    "../../node_modules/sha.js": {
+      "version": "2.4.12",
+      "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/shallow-clone-shim": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/shebang-command": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/shell-quote": {
+      "version": "1.8.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/side-channel": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/sirv": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../node_modules/slash": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "../../node_modules/snarkjs": {
+      "version": "0.7.6",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@iden3/binfileutils": "0.0.12",
+        "@noble/hashes": "^1.7.1",
+        "bfj": "^7.0.2",
+        "circom_runtime": "0.1.28",
+        "ejs": "^3.1.6",
+        "fastfile": "0.0.20",
+        "ffjavascript": "0.3.1",
+        "logplease": "^1.2.15",
+        "r1csfile": "0.0.48"
+      },
+      "bin": {
+        "snarkjs": "build/cli.cjs"
+      }
+    },
+    "../../node_modules/snarkjs/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "../../node_modules/sockjs": {
+      "version": "0.3.24",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "faye-websocket": "^0.11.3",
+        "uuid": "^8.3.2",
+        "websocket-driver": "^0.7.4"
+      }
+    },
+    "../../node_modules/socks": {
+      "version": "2.8.7",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "../../node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "../../node_modules/socks/node_modules/ip-address": {
+      "version": "10.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "../../node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "../../node_modules/source-map": {
+      "version": "0.7.6",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "../../node_modules/source-map-js": {
+      "version": "1.2.1",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/source-map-loader": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "../../node_modules/source-map-support": {
+      "version": "0.5.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "../../node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/spdy": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "../../node_modules/spdy-transport": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      }
+    },
+    "../../node_modules/spdy-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/split2": {
+      "version": "4.2.0",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "../../node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "license": "BSD-3-Clause"
+    },
+    "../../node_modules/sql-summary": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/ssri": {
+      "version": "13.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "../../node_modules/stackframe": {
+      "version": "1.3.4",
+      "license": "MIT"
+    },
+    "../../node_modules/static-eval": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "escodegen": "^1.8.1"
+      }
+    },
+    "../../node_modules/statuses": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "../../node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/stream-chopper": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^3.0.6"
+      }
+    },
+    "../../node_modules/stream-chopper/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/stream-http": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "../../node_modules/stream-http/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "../../node_modules/string-natural-compare": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/string-width": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "../../node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "../../node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "../../node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/strip-bom": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/style-loader": {
+      "version": "3.3.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "../../node_modules/sucrase": {
+      "version": "3.35.0",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "../../node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/synckit": {
+      "version": "0.11.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "../../node_modules/tailwindcss": {
+      "version": "3.4.17",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "../../node_modules/tailwindcss/node_modules/chokidar": {
+      "version": "3.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "../../node_modules/tailwindcss/node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/tailwindcss/node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/tailwindcss/node_modules/readdirp": {
+      "version": "3.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "../../node_modules/tapable": {
+      "version": "2.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/tar": {
+      "version": "7.5.13",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../../node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../../node_modules/terser": {
+      "version": "5.43.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.14.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/terser-webpack-plugin": {
+      "version": "5.3.14",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "serialize-javascript": "^6.0.2",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/text-encoding": {
+      "version": "0.7.0",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
+    },
+    "../../node_modules/text-table": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/thenify": {
+      "version": "3.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "../../node_modules/thenify-all": {
+      "version": "1.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "../../node_modules/thingies": {
+      "version": "2.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
+    "../../node_modules/thread-stream": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "../../node_modules/thunky": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/timers-browserify": {
+      "version": "2.0.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "../../node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "../../node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "../../node_modules/tmp": {
+      "version": "0.0.33",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "../../node_modules/to-buffer": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "../../node_modules/toidentifier": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "../../node_modules/totalist": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/tr46": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "../../node_modules/tr46/node_modules/punycode": {
+      "version": "2.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/tree-dump": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "../../node_modules/tryer": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "../../node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "license": "Apache-2.0"
+    },
+    "../../node_modules/ts-loader": {
+      "version": "9.5.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "^5.0.0"
+      }
+    },
+    "../../node_modules/ts-loader/node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../node_modules/ts-node": {
+      "version": "10.9.2",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "../../node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "../../node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "../../node_modules/tslib": {
+      "version": "2.8.1",
+      "license": "0BSD"
+    },
+    "../../node_modules/tsutils": {
+      "version": "3.21.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "../../node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "../../node_modules/tsyringe": {
+      "version": "4.10.0",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "../../node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "../../node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/type-check": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../node_modules/type-fest": {
+      "version": "0.20.2",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/type-is": {
+      "version": "1.6.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/typescript": {
+      "version": "4.9.5",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "../../node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/underscore": {
+      "version": "1.12.1",
+      "license": "MIT"
+    },
+    "../../node_modules/undici-types": {
+      "version": "6.21.0",
+      "license": "MIT"
+    },
+    "../../node_modules/unicode-byte-truncate": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "is-integer": "^1.0.6",
+        "unicode-substring": "^0.1.0"
+      }
+    },
+    "../../node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../node_modules/unicode-substring": {
+      "version": "0.1.0",
+      "license": "MIT"
+    },
+    "../../node_modules/universalify": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "../../node_modules/unpipe": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "../../node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "../../node_modules/uri-js/node_modules/punycode": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/url": {
+      "version": "0.11.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "../../node_modules/useragent": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "4.1.x",
+        "tmp": "0.0.x"
+      }
+    },
+    "../../node_modules/useragent/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "../../node_modules/useragent/node_modules/yallist": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/util": {
+      "version": "0.12.5",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "../../node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "../../node_modules/utila": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/utils-merge": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "../../node_modules/uuid": {
+      "version": "8.3.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "../../node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "../../node_modules/vary": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/vows": {
+      "version": "0.5.13",
+      "dependencies": {
+        "eyes": ">=0.1.6"
+      },
+      "bin": {
+        "vows": "bin/vows"
+      },
+      "engines": {
+        "node": ">=0.2.6"
+      }
+    },
+    "../../node_modules/wasmbuilder": {
+      "version": "0.0.16",
+      "license": "GPL-3.0"
+    },
+    "../../node_modules/wasmcurves": {
+      "version": "0.2.2",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "wasmbuilder": "0.0.16"
+      }
+    },
+    "../../node_modules/watchpack": {
+      "version": "2.4.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "../../node_modules/wbuf": {
+      "version": "1.7.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "../../node_modules/web-vitals": {
+      "version": "2.1.4",
+      "license": "Apache-2.0"
+    },
+    "../../node_modules/web-worker": {
+      "version": "1.2.0",
+      "license": "Apache-2.0"
+    },
+    "../../node_modules/web3": {
+      "version": "4.16.0",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-core": "^4.7.1",
+        "web3-errors": "^1.3.1",
+        "web3-eth": "^4.11.1",
+        "web3-eth-abi": "^4.4.1",
+        "web3-eth-accounts": "^4.3.1",
+        "web3-eth-contract": "^4.7.2",
+        "web3-eth-ens": "^4.4.0",
+        "web3-eth-iban": "^4.0.7",
+        "web3-eth-personal": "^4.1.0",
+        "web3-net": "^4.1.0",
+        "web3-providers-http": "^4.2.0",
+        "web3-providers-ws": "^4.0.8",
+        "web3-rpc-methods": "^1.3.0",
+        "web3-rpc-providers": "^1.0.0-rc.4",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-core": {
+      "version": "4.7.1",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-errors": "^1.3.1",
+        "web3-eth-accounts": "^4.3.1",
+        "web3-eth-iban": "^4.0.7",
+        "web3-providers-http": "^4.2.0",
+        "web3-providers-ws": "^4.0.8",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      },
+      "optionalDependencies": {
+        "web3-providers-ipc": "^4.0.7"
+      }
+    },
+    "../../node_modules/web3-errors": {
+      "version": "1.3.1",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-types": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-eth": {
+      "version": "4.11.1",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "setimmediate": "^1.0.5",
+        "web3-core": "^4.7.1",
+        "web3-errors": "^1.3.1",
+        "web3-eth-abi": "^4.4.1",
+        "web3-eth-accounts": "^4.3.1",
+        "web3-net": "^4.1.0",
+        "web3-providers-ws": "^4.0.8",
+        "web3-rpc-methods": "^1.3.0",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-eth-abi": {
+      "version": "4.4.1",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "abitype": "0.7.1",
+        "web3-errors": "^1.3.1",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-eth-accounts": {
+      "version": "4.3.1",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@ethereumjs/rlp": "^4.0.1",
+        "crc-32": "^1.2.2",
+        "ethereum-cryptography": "^2.0.0",
+        "web3-errors": "^1.3.1",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-eth-contract": {
+      "version": "4.7.2",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
+        "web3-core": "^4.7.1",
+        "web3-errors": "^1.3.1",
+        "web3-eth": "^4.11.1",
+        "web3-eth-abi": "^4.4.1",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-eth-contract/node_modules/@ethereumjs/rlp": {
+      "version": "5.0.2",
+      "license": "MPL-2.0",
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../../node_modules/web3-eth-ens": {
+      "version": "4.4.0",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.8.8",
+        "web3-core": "^4.5.0",
+        "web3-errors": "^1.2.0",
+        "web3-eth": "^4.8.0",
+        "web3-eth-contract": "^4.5.0",
+        "web3-net": "^4.1.0",
+        "web3-types": "^1.7.0",
+        "web3-utils": "^4.3.0",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-eth-iban": {
+      "version": "4.0.7",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-errors": "^1.1.3",
+        "web3-types": "^1.3.0",
+        "web3-utils": "^4.0.7",
+        "web3-validator": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-eth-personal": {
+      "version": "4.1.0",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-core": "^4.6.0",
+        "web3-eth": "^4.9.0",
+        "web3-rpc-methods": "^1.3.0",
+        "web3-types": "^1.8.0",
+        "web3-utils": "^4.3.1",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-net": {
+      "version": "4.1.0",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-core": "^4.4.0",
+        "web3-rpc-methods": "^1.3.0",
+        "web3-types": "^1.6.0",
+        "web3-utils": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-providers-http": {
+      "version": "4.2.0",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "cross-fetch": "^4.0.0",
+        "web3-errors": "^1.3.0",
+        "web3-types": "^1.7.0",
+        "web3-utils": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-providers-ipc": {
+      "version": "4.0.7",
+      "license": "LGPL-3.0",
+      "optional": true,
+      "dependencies": {
+        "web3-errors": "^1.1.3",
+        "web3-types": "^1.3.0",
+        "web3-utils": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-providers-ws": {
+      "version": "4.0.8",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@types/ws": "8.5.3",
+        "isomorphic-ws": "^5.0.0",
+        "web3-errors": "^1.2.0",
+        "web3-types": "^1.7.0",
+        "web3-utils": "^4.3.1",
+        "ws": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-rpc-methods": {
+      "version": "1.3.0",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-core": "^4.4.0",
+        "web3-types": "^1.6.0",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-rpc-providers": {
+      "version": "1.0.0-rc.4",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-errors": "^1.3.1",
+        "web3-providers-http": "^4.2.0",
+        "web3-providers-ws": "^4.0.8",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-types": {
+      "version": "1.10.0",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-utils": {
+      "version": "4.3.3",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "ethereum-cryptography": "^2.0.0",
+        "eventemitter3": "^5.0.1",
+        "web3-errors": "^1.3.1",
+        "web3-types": "^1.10.0",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/web3-validator": {
+      "version": "2.0.6",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "ethereum-cryptography": "^2.0.0",
+        "util": "^0.12.5",
+        "web3-errors": "^1.2.0",
+        "web3-types": "^1.6.0",
+        "zod": "^3.21.4"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "../../node_modules/webcrypto-core": {
+      "version": "1.8.1",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.7.0"
+      }
+    },
+    "../../node_modules/webextension-polyfill": {
+      "version": "0.10.0",
+      "dev": true,
+      "license": "MPL-2.0"
+    },
+    "../../node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "license": "BSD-2-Clause"
+    },
+    "../../node_modules/webpack": {
+      "version": "5.101.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.24.0",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.2",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.2",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.11",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.3.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "../../node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/webpack-cli": {
+      "version": "4.10.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.2.0",
+        "@webpack-cli/info": "^1.5.0",
+        "@webpack-cli/serve": "^1.7.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
+        "cross-spawn": "^7.0.3",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "@webpack-cli/migrate": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/webpack-cli/node_modules/commander": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../node_modules/webpack-dev-middleware": {
+      "version": "7.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.10",
+        "memfs": "^4.6.0",
+        "mime-types": "^2.1.31",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/webpack-dev-server": {
+      "version": "5.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/bonjour": "^3.5.13",
+        "@types/connect-history-api-fallback": "^1.5.4",
+        "@types/express": "^4.17.21",
+        "@types/express-serve-static-core": "^4.17.21",
+        "@types/serve-index": "^1.9.4",
+        "@types/serve-static": "^1.15.5",
+        "@types/sockjs": "^0.3.36",
+        "@types/ws": "^8.5.10",
+        "ansi-html-community": "^0.0.8",
+        "bonjour-service": "^1.2.1",
+        "chokidar": "^3.6.0",
+        "colorette": "^2.0.10",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^2.0.0",
+        "express": "^4.21.2",
+        "graceful-fs": "^4.2.6",
+        "http-proxy-middleware": "^2.0.9",
+        "ipaddr.js": "^2.1.0",
+        "launch-editor": "^2.6.1",
+        "open": "^10.0.3",
+        "p-retry": "^6.2.0",
+        "schema-utils": "^4.2.0",
+        "selfsigned": "^2.4.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "^0.3.24",
+        "spdy": "^4.0.2",
+        "webpack-dev-middleware": "^7.4.2",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        },
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/webpack-dev-server/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../../node_modules/webpack-dev-server/node_modules/chokidar": {
+      "version": "3.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "../../node_modules/webpack-dev-server/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../node_modules/webpack-dev-server/node_modules/readdirp": {
+      "version": "3.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "../../node_modules/webpack-ext-reloader": {
+      "version": "1.1.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webextension-polyfill": "^0.10.6",
+        "@types/webpack-sources": "^3.2.3",
+        "clean-webpack-plugin": "^4.0.0",
+        "colors": "^1.4.0",
+        "cross-env": "^7.0.3",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "useragent": "^2.3.0",
+        "webextension-polyfill": "^0.12.0",
+        "webpack-sources": "^3.2.3",
+        "ws": "^8.14.2"
+      },
+      "bin": {
+        "webpack-ext-reloader": "dist/webpack-ext-reloader-cli.js"
+      },
+      "peerDependencies": {
+        "webpack": "^5.61.0"
+      }
+    },
+    "../../node_modules/webpack-ext-reloader/node_modules/webextension-polyfill": {
+      "version": "0.12.0",
+      "dev": true,
+      "license": "MPL-2.0"
+    },
+    "../../node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "../../node_modules/webpack-sources": {
+      "version": "3.3.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "../../node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "../../node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "../../node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "../../node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "../../node_modules/which": {
+      "version": "2.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/which-collection": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../node_modules/wildcard": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../node_modules/word-wrap": {
+      "version": "1.2.5",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "../../node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "../../node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "license": "MIT"
+    },
+    "../../node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "../../node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "../../node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "../../node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "../../node_modules/ws": {
+      "version": "8.20.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/xpath": {
+      "version": "0.0.34",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "../../node_modules/xtend": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "../../node_modules/yallist": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../node_modules/yaml": {
+      "version": "2.8.1",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "../../node_modules/yazl": {
+      "version": "2.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
+    "../../node_modules/yn": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/zip-webpack-plugin": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yazl": "^2.5.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0",
+        "webpack-sources": "*"
+      }
+    },
+    "../../node_modules/zod": {
+      "version": "3.25.76",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -141,8 +18659,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
-      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -151,8 +18667,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -182,8 +18696,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -199,8 +18711,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -216,8 +18726,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -226,8 +18734,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -240,8 +18746,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -258,8 +18762,6 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -268,8 +18770,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -278,8 +18778,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -288,8 +18786,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -298,8 +18794,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -312,8 +18806,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -328,8 +18820,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -344,8 +18834,6 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -360,8 +18848,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -375,8 +18861,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -394,8 +18878,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -406,78 +18888,8 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
-      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
-      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
-      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
-      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
-      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
       "cpu": [
         "arm64"
       ],
@@ -486,363 +18898,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
-      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
-      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
-      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
-      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
-      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
-      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
-      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
-      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
-      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
-      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
-      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
-      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
-      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
-      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
-      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
-      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
-      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
-      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
-      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
-      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
-      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -850,8 +18905,6 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -869,8 +18922,6 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -882,8 +18933,6 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -892,8 +18941,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -907,8 +18954,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
-      "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -920,8 +18965,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -933,8 +18976,6 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -957,8 +18998,6 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -970,8 +19009,6 @@
     },
     "node_modules/@eslint/js": {
       "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
-      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -983,8 +19020,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -993,8 +19028,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
-      "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1007,8 +19040,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1017,8 +19048,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1031,8 +19060,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1045,8 +19072,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1059,8 +19084,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1070,8 +19093,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1081,8 +19102,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1091,15 +19110,11 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1113,43 +19128,11 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
-      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
-      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
-      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
       "cpu": [
         "arm64"
       ],
@@ -1158,278 +19141,10 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
-      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
-      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
-      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
-      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
-      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
-      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
-      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
-      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
-      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
-      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
-      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
-      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
-      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
-      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
-      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
-      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
-      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
-      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
-      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1442,8 +19157,6 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1452,8 +19165,6 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1463,8 +19174,6 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1473,22 +19182,26 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
-      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1497,8 +19210,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.1.tgz",
-      "integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1507,8 +19218,6 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1528,8 +19237,6 @@
     },
     "node_modules/acorn": {
       "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1541,8 +19248,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1551,8 +19256,6 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1568,8 +19271,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1584,22 +19285,16 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.12.tgz",
-      "integrity": "sha512-vAPMQdnyKCBtkmQA6FMCBvU9qFIppS3nzyXnEM+Lo2IAhG4Mpjv9cCxMudhgV3YdNNJv6TNqXy97dfRVL2LmaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1608,8 +19303,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1619,8 +19312,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.26.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
-      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
       "dev": true,
       "funding": [
         {
@@ -1653,8 +19344,6 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1663,8 +19352,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001748",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001748.tgz",
-      "integrity": "sha512-5P5UgAr0+aBmNiplks08JLw+AW/XG/SurlgZLgB1dDLfAw7EfRGxIwzPHxdSCGY/BTKDqIVyJL87cCN6s0ZR0w==",
       "dev": true,
       "funding": [
         {
@@ -1684,8 +19371,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1701,8 +19386,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1714,29 +19397,21 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1749,16 +19424,12 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1775,22 +19446,16 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.232",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.232.tgz",
-      "integrity": "sha512-ENirSe7wf8WzyPCibqKUG1Cg43cPaxH4wRR7AJsX7MCABCHBIOFqvaYODSLKUuZdraxUTHRE/0A2Aq8BYKEHOg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
-      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1831,8 +19496,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1841,8 +19504,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1854,8 +19515,6 @@
     },
     "node_modules/eslint": {
       "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
-      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1915,8 +19574,6 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1928,8 +19585,6 @@
     },
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.23.tgz",
-      "integrity": "sha512-G4j+rv0NmbIR45kni5xJOrYvCtyD3/7LjpVH8MPPcudXDcNu8gv+4ATTDXTtbRR8rTCM5HxECvCSsRmxKnWDsA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1938,8 +19593,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1955,8 +19608,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1968,8 +19619,6 @@
     },
     "node_modules/espree": {
       "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1986,8 +19635,6 @@
     },
     "node_modules/esquery": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1999,8 +19646,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2012,8 +19657,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -2022,8 +19665,6 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -2032,29 +19673,21 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2071,8 +19704,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2084,8 +19715,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2101,8 +19730,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2115,17 +19742,12 @@
     },
     "node_modules/flatted": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2137,8 +19759,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2147,8 +19767,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2160,8 +19778,6 @@
     },
     "node_modules/globals": {
       "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
-      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2173,8 +19789,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2183,8 +19797,6 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2193,8 +19805,6 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2210,8 +19820,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2220,8 +19828,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2230,8 +19836,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2243,22 +19847,26 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2270,8 +19878,6 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2283,29 +19889,21 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2317,8 +19915,6 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2327,8 +19923,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2341,8 +19935,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2357,15 +19949,11 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2374,8 +19962,6 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2387,15 +19973,11 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -2413,22 +19995,16 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
-      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2445,8 +20021,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2461,8 +20035,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2477,8 +20049,6 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2490,8 +20060,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2500,8 +20068,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2510,15 +20076,11 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2530,8 +20092,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -2559,8 +20119,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2569,8 +20127,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2579,8 +20135,6 @@
     },
     "node_modules/react": {
       "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2588,8 +20142,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -2600,8 +20152,6 @@
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2610,8 +20160,6 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2620,8 +20168,6 @@
     },
     "node_modules/rollup": {
       "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
-      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2662,14 +20208,10 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2678,8 +20220,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2691,8 +20231,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2701,8 +20239,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2711,8 +20247,6 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2724,8 +20258,6 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2737,8 +20269,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2754,8 +20284,6 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2765,10 +20293,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dev": true,
       "funding": [
         {
@@ -2798,8 +20331,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2808,8 +20339,6 @@
     },
     "node_modules/vite": {
       "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
-      "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2883,8 +20412,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2899,8 +20426,6 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2909,15 +20434,11 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/examples/basic-extension/public/manifest.json
+++ b/examples/basic-extension/public/manifest.json
@@ -12,7 +12,7 @@
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; worker-src 'self';"
   },
   "host_permissions": ["<all_urls>"],
-  "permissions": ["offscreen", "cookies", "scripting", "storage", "declarativeNetRequest"],
+  "permissions": ["offscreen", "cookies", "scripting", "storage", "declarativeNetRequest", "alarms"],
   "content_scripts": [
     {
       "js": ["reclaim-browser-extension-sdk/content/content.bundle.js", "extensionContent.js"],

--- a/examples/basic-extension/public/popup.js
+++ b/examples/basic-extension/public/popup.js
@@ -25,6 +25,17 @@ document.getElementById("startBtn").addEventListener("click", async () => {
 
     request = await reclaimExtensionSDK.init(appId, appSecret, providerId, {
       extensionID: "giclhcgjpilblajdkdkdboobjpaoanlk",
+
+      // Full local logging while developing. Defaults are consoleEnabled:false
+      // and logLevel:"INFO" because a consumer extension ships to end users.
+      // Applied first inside init(), so session-init and provider-fetch logs
+      // are captured too. Read them in: chrome://extensions → "service worker"
+      // (background), "Inspect views: offscreen/offscreen.html" (offscreen),
+      // and the provider tab's console (content script + interceptor).
+      logConfig: {
+        logLevel: "DEBUG",
+        consoleEnabled: true,
+      },
     });
 
     console.log("[popup] request", request);

--- a/examples/web-app/package-lock.json
+++ b/examples/web-app/package-lock.json
@@ -26,21 +26,25 @@
     },
     "../..": {
       "name": "@reclaimprotocol/browser-extension-sdk",
-      "version": "0.3.0",
+      "version": "0.5.0-dev.1",
       "license": "MIT",
       "dependencies": {
         "@extism/extism": "^1.0.3",
-        "@reclaimprotocol/attestor-core": "^5.0.5",
+        "@reclaimprotocol/attestor-core": "5.0.5",
         "@reclaimprotocol/tls": "git+https://git@github.com/reclaimprotocol/tls.git#8e0669a220341432673a20bb51f9339555701ef4",
         "@reclaimprotocol/zk-symmetric-crypto": "^5.1.3",
         "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "child_process": "^1.0.2",
         "crypto-browserify": "3.12.1",
+        "domhandler": "^5.0.3",
+        "esprima-next": "^5.8.4",
         "ethers": "^6.13.1",
-        "jsonpath-plus": "^10.3.0",
+        "jsonpath-plus": "^10.4.0",
         "os-browserify": "^0.3.0",
         "p-queue": "^8.0.1",
+        "parse5": "^8.0.0",
+        "parse5-htmlparser2-tree-adapter": "^8.0.0",
         "path-browserify": "1.0.1",
         "process": "^0.11.10",
         "react": "^18.2.0",
@@ -55,7 +59,8 @@
         "stream-browserify": "^3.0.0",
         "tailwindcss": "^3.3.3",
         "web-vitals": "^2.1.4",
-        "web3": "^4.10.0"
+        "web3": "^4.10.0",
+        "xpath": "^0.0.34"
       },
       "devDependencies": {
         "@babel/core": "^7.20.12",
@@ -124,28 +129,14 @@
         "zip-webpack-plugin": "^4.0.1"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -154,9 +145,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -164,22 +155,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.6",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -195,14 +186,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -212,14 +203,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -229,9 +220,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -239,29 +230,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -271,9 +262,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -281,9 +272,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -291,9 +282,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -301,9 +292,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -311,27 +302,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
-      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -341,13 +332,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -357,13 +348,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -373,33 +364,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -407,23 +398,23 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
       "cpu": [
         "ppc64"
       ],
@@ -438,9 +429,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
       "cpu": [
         "arm"
       ],
@@ -455,9 +446,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "cpu": [
         "arm64"
       ],
@@ -472,9 +463,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "cpu": [
         "x64"
       ],
@@ -489,9 +480,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
       "cpu": [
         "arm64"
       ],
@@ -506,9 +497,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "cpu": [
         "x64"
       ],
@@ -523,9 +514,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
       "cpu": [
         "arm64"
       ],
@@ -540,9 +531,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "cpu": [
         "x64"
       ],
@@ -557,9 +548,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "cpu": [
         "arm"
       ],
@@ -574,9 +565,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
       "cpu": [
         "arm64"
       ],
@@ -591,9 +582,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
       "cpu": [
         "ia32"
       ],
@@ -608,9 +599,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "cpu": [
         "loong64"
       ],
@@ -625,9 +616,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
       "cpu": [
         "mips64el"
       ],
@@ -642,9 +633,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -659,9 +650,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
       "cpu": [
         "riscv64"
       ],
@@ -676,9 +667,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "cpu": [
         "s390x"
       ],
@@ -693,9 +684,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
       "cpu": [
         "x64"
       ],
@@ -710,9 +701,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
       "cpu": [
         "arm64"
       ],
@@ -727,9 +718,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
       "cpu": [
         "x64"
       ],
@@ -744,9 +735,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "cpu": [
         "arm64"
       ],
@@ -761,9 +752,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
       "cpu": [
         "x64"
       ],
@@ -778,9 +769,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
       "cpu": [
         "arm64"
       ],
@@ -795,9 +786,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
       "cpu": [
         "x64"
       ],
@@ -812,9 +803,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "cpu": [
         "arm64"
       ],
@@ -829,9 +820,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
       "cpu": [
         "ia32"
       ],
@@ -846,9 +837,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "cpu": [
         "x64"
       ],
@@ -863,9 +854,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -895,9 +886,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -905,34 +896,37 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -943,20 +937,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -980,9 +974,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
-      "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -993,9 +987,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1003,13 +997,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.2",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1017,41 +1011,41 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -1093,6 +1087,17 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1104,16 +1109,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1121,21 +1126,38 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@reclaimprotocol/browser-extension-sdk": {
       "resolved": "../..",
       "link": true
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.30.tgz",
-      "integrity": "sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw==",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
-      "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
       "cpu": [
         "arm"
       ],
@@ -1147,9 +1169,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
-      "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
       "cpu": [
         "arm64"
       ],
@@ -1161,9 +1183,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
-      "integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
       "cpu": [
         "arm64"
       ],
@@ -1175,9 +1197,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
-      "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
       "cpu": [
         "x64"
       ],
@@ -1189,9 +1211,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
-      "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
       "cpu": [
         "arm64"
       ],
@@ -1203,9 +1225,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
-      "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
       "cpu": [
         "x64"
       ],
@@ -1217,9 +1239,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
-      "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
       "cpu": [
         "arm"
       ],
@@ -1231,9 +1253,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
-      "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
       "cpu": [
         "arm"
       ],
@@ -1245,9 +1267,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
-      "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
       "cpu": [
         "arm64"
       ],
@@ -1259,9 +1281,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
-      "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
       "cpu": [
         "arm64"
       ],
@@ -1272,10 +1294,24 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
-      "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
       "cpu": [
         "loong64"
       ],
@@ -1287,9 +1323,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
-      "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
       "cpu": [
         "ppc64"
       ],
@@ -1301,9 +1351,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
-      "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
       "cpu": [
         "riscv64"
       ],
@@ -1315,9 +1365,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
-      "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1329,9 +1379,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
-      "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
       "cpu": [
         "s390x"
       ],
@@ -1343,9 +1393,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
-      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
       "cpu": [
         "x64"
       ],
@@ -1357,9 +1407,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
-      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
       "cpu": [
         "x64"
       ],
@@ -1370,10 +1420,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
-      "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
       "cpu": [
         "arm64"
       ],
@@ -1385,9 +1463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
-      "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
       "cpu": [
         "ia32"
       ],
@@ -1398,10 +1476,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
-      "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
       "cpu": [
         "x64"
       ],
@@ -1458,9 +1550,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1472,50 +1564,50 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
-      "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
-      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.0.tgz",
-      "integrity": "sha512-Jx9JfsTa05bYkS9xo0hkofp2dCmp1blrKjw9JONs5BTHOvJCgLbaPSuZLGSVJW6u2qe0tc4eevY0+gSNNi0YCw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
+        "@babel/core": "^7.29.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.30",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
         "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "react-refresh": "^0.18.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1536,9 +1628,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1582,10 +1674,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1594,9 +1699,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
-      "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -1614,10 +1719,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001733",
-        "electron-to-chromium": "^1.5.199",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1637,9 +1743,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001734",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
-      "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -1724,16 +1830,16 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1756,16 +1862,16 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
-      "integrity": "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==",
+      "version": "1.5.416",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.416.tgz",
+      "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/esbuild": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1776,32 +1882,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.9",
-        "@esbuild/android-arm": "0.25.9",
-        "@esbuild/android-arm64": "0.25.9",
-        "@esbuild/android-x64": "0.25.9",
-        "@esbuild/darwin-arm64": "0.25.9",
-        "@esbuild/darwin-x64": "0.25.9",
-        "@esbuild/freebsd-arm64": "0.25.9",
-        "@esbuild/freebsd-x64": "0.25.9",
-        "@esbuild/linux-arm": "0.25.9",
-        "@esbuild/linux-arm64": "0.25.9",
-        "@esbuild/linux-ia32": "0.25.9",
-        "@esbuild/linux-loong64": "0.25.9",
-        "@esbuild/linux-mips64el": "0.25.9",
-        "@esbuild/linux-ppc64": "0.25.9",
-        "@esbuild/linux-riscv64": "0.25.9",
-        "@esbuild/linux-s390x": "0.25.9",
-        "@esbuild/linux-x64": "0.25.9",
-        "@esbuild/netbsd-arm64": "0.25.9",
-        "@esbuild/netbsd-x64": "0.25.9",
-        "@esbuild/openbsd-arm64": "0.25.9",
-        "@esbuild/openbsd-x64": "0.25.9",
-        "@esbuild/openharmony-arm64": "0.25.9",
-        "@esbuild/sunos-x64": "0.25.9",
-        "@esbuild/win32-arm64": "0.25.9",
-        "@esbuild/win32-ia32": "0.25.9",
-        "@esbuild/win32-x64": "0.25.9"
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escalade": {
@@ -1828,26 +1934,26 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
-      "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.1",
-        "@eslint/core": "^0.15.2",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.33.0",
-        "@eslint/plugin-kit": "^0.3.5",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -1866,7 +1972,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1902,9 +2008,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.20.tgz",
-      "integrity": "sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1960,9 +2066,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2027,11 +2133,14 @@
       "license": "MIT"
     },
     "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -2086,9 +2195,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -2131,9 +2240,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2228,10 +2337,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2345,9 +2464,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2365,9 +2484,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2391,11 +2510,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2488,9 +2610,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2501,9 +2623,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2521,7 +2643,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2550,30 +2672,30 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.1"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2591,13 +2713,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.46.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
-      "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2607,33 +2729,39 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.46.2",
-        "@rollup/rollup-android-arm64": "4.46.2",
-        "@rollup/rollup-darwin-arm64": "4.46.2",
-        "@rollup/rollup-darwin-x64": "4.46.2",
-        "@rollup/rollup-freebsd-arm64": "4.46.2",
-        "@rollup/rollup-freebsd-x64": "4.46.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.46.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.46.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.46.2",
-        "@rollup/rollup-linux-arm64-musl": "4.46.2",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.46.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.46.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.46.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.46.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.46.2",
-        "@rollup/rollup-linux-x64-gnu": "4.46.2",
-        "@rollup/rollup-linux-x64-musl": "4.46.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.46.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.46.2",
-        "@rollup/rollup-win32-x64-msvc": "4.46.2",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -2706,14 +2834,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2736,9 +2864,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {
@@ -2777,18 +2905,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.2.tgz",
-      "integrity": "sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.6",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/examples/web-app/src/ReclaimDemo.jsx
+++ b/examples/web-app/src/ReclaimDemo.jsx
@@ -3,8 +3,11 @@ import { reclaimExtensionSDK } from '@reclaimprotocol/browser-extension-sdk';
 import './ReclaimDemo.css';
 
 const PROVIDERS = [
+  {id:'example', name: 'Example Provider'},
   { id: '7519ad78-208a-425d-9fac-97c13b0f0d4d', name: 'Kaggle Oprf' },
   {id: '33c5d558-ad53-4c4b-b500-a9f41f7ff1f7', name: 'Reclaim Test Provider'},
+  {id: '666e5b03-92cc-4f85-8cc2-708fafe3fdff', name: "githb chainbound"},
+  {id: '23d24ecd-ef60-4490-8eb4-360301282d8e', name: 'ether scan'}
 ];
 
 const APP_ID = import.meta.env.VITE_RECLAIM_APP_ID;
@@ -212,6 +215,27 @@ export default function ReclaimDemo() {
       const request = await reclaimExtensionSDK.init(APP_ID, APP_SECRET, providerId, {
         extensionID: EXTENSION_ID,
         // callbackUrl: 'https://your.server/receive-proofs' // optional
+
+        // Full local logging while developing. The SDK ships with
+        // consoleEnabled: false and logLevel: "INFO", because a consumer
+        // extension goes to end users and the content-script console is the
+        // *provider tab's* console.
+        //
+        // logConfig is applied before anything else in init(), so this also
+        // captures the session-init and provider-fetch logs.
+        //
+        // Where the output lands (one console per extension context):
+        //   background  → chrome://extensions → the extension → "service worker"
+        //   offscreen   → same page → "Inspect views: offscreen/offscreen.html"
+        //   content     → the provider tab's own DevTools console
+        //   interceptor → the provider tab's console too (MAIN world)
+        //
+        // remoteLogLevel is left alone: it already defaults to DEBUG, so the
+        // diagnostic endpoint receives everything regardless of this setting.
+        logConfig: {
+          logLevel: 'DEBUG',
+          consoleEnabled: true,
+        },
       });
 
       // request.setAppCallbackUrl("https://your-server.com/receive-proofs");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,30 @@
 {
   "name": "@reclaimprotocol/browser-extension-sdk",
-  "version": "0.4.1",
+  "version": "0.5.0-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reclaimprotocol/browser-extension-sdk",
-      "version": "0.4.1",
+      "version": "0.5.0-dev.1",
       "license": "MIT",
       "dependencies": {
         "@extism/extism": "^1.0.3",
-        "@reclaimprotocol/attestor-core": "^5.0.5",
+        "@reclaimprotocol/attestor-core": "5.1.1",
         "@reclaimprotocol/tls": "git+https://git@github.com/reclaimprotocol/tls.git#8e0669a220341432673a20bb51f9339555701ef4",
         "@reclaimprotocol/zk-symmetric-crypto": "^5.1.3",
         "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "child_process": "^1.0.2",
         "crypto-browserify": "3.12.1",
+        "domhandler": "^5.0.3",
+        "esprima-next": "^5.8.4",
         "ethers": "^6.13.1",
-        "jsonpath-plus": "^10.3.0",
+        "jsonpath-plus": "^10.4.0",
         "os-browserify": "^0.3.0",
         "p-queue": "^8.0.1",
+        "parse5": "^8.0.0",
+        "parse5-htmlparser2-tree-adapter": "^8.0.0",
         "path-browserify": "1.0.1",
         "process": "^0.11.10",
         "react": "^18.2.0",
@@ -35,7 +39,8 @@
         "stream-browserify": "^3.0.0",
         "tailwindcss": "^3.3.3",
         "web-vitals": "^2.1.4",
-        "web3": "^4.10.0"
+        "web3": "^4.10.0",
+        "xpath": "^0.0.34"
       },
       "devDependencies": {
         "@babel/core": "^7.20.12",
@@ -167,7 +172,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -758,7 +762,6 @@
       "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1603,7 +1606,6 @@
       "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-module-imports": "^7.27.1",
@@ -2177,6 +2179,7 @@
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -2190,6 +2193,7 @@
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2251,7 +2255,6 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2378,7 +2381,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2402,7 +2404,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -2525,7 +2526,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2549,7 +2549,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -2622,7 +2621,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -2695,7 +2693,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2719,7 +2716,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -2867,7 +2863,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2891,7 +2886,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -3014,7 +3008,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -3038,7 +3031,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -3161,7 +3153,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -3185,7 +3176,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -3297,7 +3287,6 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3374,7 +3363,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -3590,7 +3578,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -3614,7 +3601,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -3687,7 +3673,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -3711,7 +3696,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -3911,7 +3895,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -3935,7 +3918,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -4084,7 +4066,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -4108,7 +4089,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -4221,7 +4201,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -4245,7 +4224,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -4365,7 +4343,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -4389,7 +4366,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -4594,6 +4570,7 @@
       "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
       "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -4701,6 +4678,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -4937,6 +4915,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -5001,6 +4991,7 @@
       "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
       "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -5017,6 +5008,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
       "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -5026,6 +5018,7 @@
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
       "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -5038,6 +5031,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5050,6 +5044,7 @@
       "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
       "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -5059,7 +5054,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5692,16 +5686,16 @@
       "license": "MIT"
     },
     "node_modules/@reclaimprotocol/attestor-core": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@reclaimprotocol/attestor-core/-/attestor-core-5.0.5.tgz",
-      "integrity": "sha512-pMJs69OApuKqlfKO35j/hCENSpfyPbasFRNmN3GRr4IsUinsU8fl/yQxW9CgIwjIz5WO4wXiGmuYDpTDmpbTzw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@reclaimprotocol/attestor-core/-/attestor-core-5.1.1.tgz",
+      "integrity": "sha512-6Bg7KohGUlQ3UvUaXXEo1ZKi49J/hXZ1hyGZYG0roQWq95yDHQT7Sq9sn/8Qee0y+OULwCL7UrqXt+lbQDYOIQ==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
         "@peculiar/asn1-x509": "^2.6.1",
         "@peculiar/webcrypto": "^1.5.0",
         "@peculiar/x509": "^1.14.3",
-        "@reclaimprotocol/tls": "github:reclaimprotocol/tls",
+        "@reclaimprotocol/tls": "^0.1.3",
         "@reclaimprotocol/zk-symmetric-crypto": "^5.1.3",
         "ajv": "^8.18.0",
         "bs58": "^6.0.0",
@@ -5721,11 +5715,55 @@
         "parse5": "^8.0.0",
         "parse5-htmlparser2-tree-adapter": "^8.0.0",
         "pino": "^9.14.0",
-        "re2": "^1.23.3",
         "serve-static": "^1.16.3",
         "snarkjs": "^0.7.6",
         "ws": "^8.20.0",
         "xpath": "^0.0.34"
+      },
+      "optionalDependencies": {
+        "re2": "*"
+      }
+    },
+    "node_modules/@reclaimprotocol/attestor-core/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@reclaimprotocol/attestor-core/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@reclaimprotocol/attestor-core/node_modules/@reclaimprotocol/tls": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@reclaimprotocol/tls/-/tls-0.1.3.tgz",
+      "integrity": "sha512-mBDqygz5FAsH8OGaZUGb5HEoP4hGSVT8WL6YOk50gzmiFsLYRTf2928FOEpQOKlG3kXK+PDy0vJbFDQPw0l5Ag==",
+      "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
+      "dependencies": {
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.6",
+        "@noble/hashes": "^1.8.0",
+        "@peculiar/asn1-ecc": "^2.3.14",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/x509": "^1.12.3",
+        "micro-rsa-dsa-dh": "^0.1.0"
       }
     },
     "node_modules/@reclaimprotocol/attestor-core/node_modules/debug": {
@@ -5742,18 +5780,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/@reclaimprotocol/attestor-core/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/@reclaimprotocol/attestor-core/node_modules/http-errors": {
       "version": "2.0.1",
@@ -5782,18 +5808,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/@reclaimprotocol/attestor-core/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/@reclaimprotocol/attestor-core/node_modules/send": {
@@ -5849,7 +5863,6 @@
       "resolved": "git+https://git@github.com/reclaimprotocol/tls.git#8e0669a220341432673a20bb51f9339555701ef4",
       "integrity": "sha512-XMBM7rXt2jzrhc4iCIFT25bKEbiJMvw/Makl5V+F02AkkXhtu/opCdzWWpe/JotQ4V8PvHnPaVryk+QO/GVIrg==",
       "license": "See License in <https://github.com/reclaimprotocol/.github/blob/main/LICENSE>",
-      "peer": true,
       "dependencies": {
         "@peculiar/asn1-ecc": "^2.3.14",
         "@peculiar/asn1-schema": "^2.3.13",
@@ -6051,28 +6064,32 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -6133,7 +6150,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6294,7 +6310,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
       "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6341,7 +6356,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6353,7 +6367,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -6570,7 +6583,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -7054,6 +7066,7 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
       "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -7114,7 +7127,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7211,7 +7223,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8254,7 +8265,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -8363,6 +8373,7 @@
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
       "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "@npmcli/fs": "^5.0.0",
         "fs-minipass": "^3.0.0",
@@ -8384,6 +8395,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -8393,6 +8405,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -8405,6 +8418,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
@@ -8422,6 +8436,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
       "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -8431,6 +8446,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^5.0.5"
       },
@@ -8446,6 +8462,7 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
       "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -8458,6 +8475,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -8669,6 +8687,7 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -9302,7 +9321,6 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9398,6 +9416,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/css-what": {
@@ -9766,6 +9800,7 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -9859,6 +9894,22 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
+    "node_modules/dom-serializer/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dom-serializer/node_modules/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -9895,13 +9946,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       },
       "engines": {
         "node": ">= 4"
@@ -9923,6 +9973,22 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/domutils/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/dot-case": {
@@ -10264,6 +10330,7 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -10629,7 +10696,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10686,7 +10752,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11348,7 +11413,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/express": {
       "version": "4.21.2",
@@ -11631,7 +11697,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11985,6 +12050,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
       "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -12250,6 +12316,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -12493,6 +12560,32 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/html-loader/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-loader/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/html-minifier-terser": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
@@ -12600,6 +12693,22 @@
         "entities": "^2.0.0"
       }
     },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/htmlparser2/node_modules/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -12614,7 +12723,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
@@ -12676,6 +12786,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -12992,6 +13103,7 @@
       "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.4.0.tgz",
       "integrity": "sha512-+y6WywKZREw5rq7U2jvr2nmZpT7cbWbQQ0N/qfcseYnzHFz2cZz1Et52oY+XttYuYeTkI8Y+R2JNWj68MpQFSg==",
       "license": "BSD-3-Clause",
+      "optional": true,
       "bin": {
         "install-from-cache": "bin/install-from-cache.js",
         "save-to-github-cache": "bin/save-to-github-cache.js"
@@ -13814,7 +13926,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -14143,13 +14254,15 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/make-fetch-happen": {
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
       "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
@@ -14431,6 +14544,7 @@
       "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
       "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -14443,6 +14557,7 @@
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
       "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^2.0.0",
@@ -14477,6 +14592,7 @@
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
       "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -14489,6 +14605,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14500,13 +14617,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -14519,6 +14638,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14530,13 +14650,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/minipass-sized": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
       "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -14549,6 +14671,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -14613,7 +14736,8 @@
       "version": "2.26.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
       "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -14652,6 +14776,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14745,6 +14870,7 @@
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
       "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -14794,6 +14920,7 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
       "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=20"
       }
@@ -14803,6 +14930,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -14815,6 +14943,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
       "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "isexe": "^4.0.0"
       },
@@ -14988,6 +15117,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
       "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "^4.0.0"
       },
@@ -15518,13 +15648,12 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -15543,53 +15672,13 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -15984,7 +16073,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16168,7 +16256,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -16192,7 +16279,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -16320,7 +16406,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -16344,7 +16429,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -16443,7 +16527,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -16467,7 +16550,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -16541,7 +16623,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -16565,7 +16646,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -16946,7 +17026,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -16970,7 +17049,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -17253,7 +17331,6 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -17559,7 +17636,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17599,6 +17675,7 @@
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
       "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -17864,6 +17941,7 @@
       "integrity": "sha512-pBm6cMaOb0Yb0kg0Sfw/k4LwDMkPScb/NVd7GrEllDwfsPZstsZIo93A6Nn0wZuWJw3h57GdzkrOk81EofKY/g==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "install-artifact-from-github": "^1.4.0",
         "nan": "^2.26.2",
@@ -17878,7 +17956,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17891,7 +17968,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17957,7 +18033,6 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18097,7 +18172,6 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -18545,7 +18619,6 @@
       "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -19066,6 +19139,7 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -19120,6 +19194,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -19134,6 +19209,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -19148,6 +19224,7 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -19296,6 +19373,7 @@
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
       "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -19863,6 +19941,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
       "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -19879,6 +19958,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -20031,6 +20111,7 @@
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -20047,6 +20128,7 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -20064,7 +20146,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -20225,6 +20307,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -20268,7 +20351,8 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -20300,8 +20384,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -20370,7 +20453,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20475,7 +20557,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20749,7 +20830,8 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -21219,7 +21301,6 @@
       "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -21328,7 +21409,6 @@
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",
@@ -21417,7 +21497,6 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -21586,7 +21665,6 @@
       "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -21882,7 +21960,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -21969,6 +22046,7 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -22005,7 +22083,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/browser-extension-sdk",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "module": "build/ReclaimExtensionSDK.bundle.js",
   "exports": {
     ".": {
@@ -22,7 +22,7 @@
   "scripts": {
     "prebuild": "prettier --write .",
     "build": "NODE_ENV=production node webpack-build-utils/build.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test \"src/**/*.test.js\"",
     "postinstall1": "./script.sh",
     "format": "prettier --write .",
     "prepublishOnly": "npm run build"
@@ -58,17 +58,21 @@
   "license": "MIT",
   "dependencies": {
     "@extism/extism": "^1.0.3",
-    "@reclaimprotocol/attestor-core": "^5.0.5",
+    "@reclaimprotocol/attestor-core": "5.1.1",
     "@reclaimprotocol/tls": "git+https://git@github.com/reclaimprotocol/tls.git#8e0669a220341432673a20bb51f9339555701ef4",
     "@reclaimprotocol/zk-symmetric-crypto": "^5.1.3",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "child_process": "^1.0.2",
     "crypto-browserify": "3.12.1",
+    "domhandler": "^5.0.3",
+    "esprima-next": "^5.8.4",
     "ethers": "^6.13.1",
-    "jsonpath-plus": "^10.3.0",
+    "jsonpath-plus": "^10.4.0",
     "os-browserify": "^0.3.0",
     "p-queue": "^8.0.1",
+    "parse5": "^8.0.0",
+    "parse5-htmlparser2-tree-adapter": "^8.0.0",
     "path-browserify": "1.0.1",
     "process": "^0.11.10",
     "react": "^18.2.0",
@@ -83,7 +87,8 @@
     "stream-browserify": "^3.0.0",
     "tailwindcss": "^3.3.3",
     "web-vitals": "^2.1.4",
-    "web3": "^4.10.0"
+    "web3": "^4.10.0",
+    "xpath": "^0.0.34"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/readme.md
+++ b/readme.md
@@ -1,24 +1,20 @@
 # Reclaim Protocol Browser Extension SDK
 
-SDK to trigger Reclaim zero-knowledge proof verification flows from your website or browser extension.
+Trigger Reclaim zero-knowledge proof verification from your browser extension or website.
 
-> Chrome **Manifest V3** compatible.
+> Chrome **Manifest V3**. MV2/Firefox bundles are also included.
 
----
-
-## Quick Start
-
-### 1. Install
+## Install
 
 ```bash
 npm i @reclaimprotocol/browser-extension-sdk
 ```
 
-### 2. Copy SDK Assets
+## 1. Copy the SDK assets
 
-The SDK ships prebuilt bundles that must be copied into your extension's `public/` folder (they cannot be re-bundled).
+The SDK ships prebuilt bundles that must be copied into your extension's `public/` folder — they cannot be re-bundled.
 
-Add to your `package.json`:
+Add the script to your `package.json`:
 
 ```json
 {
@@ -28,15 +24,15 @@ Add to your `package.json`:
 }
 ```
 
-Then run:
+Then run it (after every `npm install`):
 
 ```bash
 npm run reclaim-extension-setup
 ```
 
-### 3. Manifest Setup
+This also downloads the ZK circuits (~280 MB, cached after the first run).
 
-Add these to your `manifest.json`:
+## 2. Update your manifest
 
 ```json
 {
@@ -44,7 +40,14 @@ Add these to your `manifest.json`:
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; worker-src 'self';"
   },
   "host_permissions": ["<all_urls>"],
-  "permissions": ["offscreen", "cookies", "scripting", "storage", "declarativeNetRequest"],
+  "permissions": [
+    "offscreen",
+    "cookies",
+    "scripting",
+    "storage",
+    "declarativeNetRequest",
+    "alarms"
+  ],
   "content_scripts": [
     {
       "js": ["reclaim-browser-extension-sdk/content/content.bundle.js"],
@@ -71,29 +74,20 @@ Add these to your `manifest.json`:
 }
 ```
 
-**Why these permissions:**
+All of it is required. `wasm-unsafe-eval` runs the ZK prover, `offscreen` hosts it, `cookies` reads the provider's auth session, and `scripting` + `declarativeNetRequest` let provider scripts run on strict-CSP sites (scoped to one hostname, only while a verification is in progress, removed when it ends).
 
-| Permission              | Reason                                                                     |
-| ----------------------- | -------------------------------------------------------------------------- |
-| `wasm-unsafe-eval`      | WebAssembly for ZK proof generation                                        |
-| `offscreen`             | Background proof generation via offscreen document                         |
-| `cookies`               | Access provider auth cookies                                               |
-| `scripting`             | Content script registration and custom injection                           |
-| `storage`               | SDK config and session state                                               |
-| `declarativeNetRequest` | Temporary CSP header modification for custom injection on strict-CSP sites |
-
-### 4. Initialize Background
+## 3. Initialize the background
 
 ```js
-// In your service worker (background.js)
+// service worker (background.js)
 import { reclaimExtensionSDK } from "@reclaimprotocol/browser-extension-sdk";
 
 reclaimExtensionSDK.initializeBackground();
 ```
 
-### 5. Start Verification
+## 4. Start a verification
 
-**From extension popup/panel:**
+From your extension's popup or side panel:
 
 ```js
 import { reclaimExtensionSDK } from "@reclaimprotocol/browser-extension-sdk";
@@ -102,84 +96,51 @@ const request = await reclaimExtensionSDK.init(APP_ID, APP_SECRET, PROVIDER_ID);
 
 request.on("completed", (proofs) => console.log(proofs));
 request.on("error", (err) => console.error(err));
-```
-
-**From a web page** (pass your extension ID):
-
-```js
-import { reclaimExtensionSDK } from "@reclaimprotocol/browser-extension-sdk";
-
-const request = await reclaimExtensionSDK.init(APP_ID, APP_SECRET, PROVIDER_ID, {
-  extensionID: "your-chrome-extension-id",
-});
-
-request.on("completed", (proofs) => console.log(proofs));
-request.on("error", (err) => console.error(err));
 
 await request.startVerification();
 ```
 
----
-
-## Server-Side Config (Optional)
-
-To avoid exposing keys client-side, generate a signed config on your server using `@reclaimprotocol/js-sdk`:
+From a web page — same thing, but pass your extension ID:
 
 ```js
-// Server
+const request = await reclaimExtensionSDK.init(APP_ID, APP_SECRET, PROVIDER_ID, {
+  extensionID: "your-chrome-extension-id",
+});
+```
+
+That's it. The SDK opens the provider's site, waits for the user to sign in, builds the claim, and resolves `completed` with the proofs.
+
+## Keeping your app secret off the client
+
+Generate a signed config on your server with `@reclaimprotocol/js-sdk`:
+
+```js
+// server
 const { ReclaimProofRequest } = require("@reclaimprotocol/js-sdk");
 
-const reclaimProofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER_ID);
-reclaimProofRequest.setAppCallbackUrl("https://your-domain.com/receive-proofs");
-const config = reclaimProofRequest.toJsonString();
+const proofRequest = await ReclaimProofRequest.init(APP_ID, APP_SECRET, PROVIDER_ID);
+proofRequest.setAppCallbackUrl("https://your-domain.com/receive-proofs");
+const config = proofRequest.toJsonString();
 ```
 
 ```js
-// Client
+// client
 const request = await reclaimExtensionSDK.fromJsonString(config, {
   extensionID: "your-chrome-extension-id",
 });
 ```
 
----
-
-## How Circuit Assets Are Fetched
-
-The SDK relies on Zero-Knowledge circuit binaries (~280MB) provided by [`@reclaimprotocol/zk-symmetric-crypto`](https://www.npmjs.com/package/@reclaimprotocol/zk-symmetric-crypto), pulled in as a transitive dependency.
-
-When you run `npm run reclaim-extension-setup`:
-
-1. If `node_modules/@reclaimprotocol/zk-symmetric-crypto/resources/` is missing, the setup script invokes the upstream package's downloader to populate it (one-time; cached across re-runs).
-2. That `resources/` folder is then copied into `<your-extension>/public/browser-rpc/resources/`, which is what the manifest's `web_accessible_resources` points at.
-
-**CI / Docker tip:** Run `npm run reclaim-extension-setup` _after_ `npm install`. If your pipeline prunes `node_modules` between steps, the circuits will be re-downloaded the next time setup runs.
-
----
-
-## Custom Injections & CSP
-
-Some providers ship a small `customInjection` script that must run on the provider's page to extract data. On strict-CSP sites (e.g. LinkedIn), inline execution is blocked, so the SDK uses `chrome.scripting.executeScript` to inject into the MAIN world and temporarily strips the page's CSP header via a `chrome.declarativeNetRequest` **session rule**.
-
-**This is safe:** the rule is scoped to a single provider hostname, only active for the duration of an in-progress verification, and auto-removed on session end, failure, or after a max lifetime. This is why the manifest needs `declarativeNetRequest` and `scripting` permissions.
-
----
-
 ## Troubleshooting
 
-| Issue                               | Fix                                                                         |
-| ----------------------------------- | --------------------------------------------------------------------------- |
-| `Unexpected token 'export'`         | Load `content.bundle.js` (classic), not an ESM file                         |
-| `must specify Extension ID`         | Pass `{ extensionID }` when calling from a web page                         |
-| Provider tab doesn't open           | Check assets, permissions, background init, and content script registration |
-| Proof generation fails with snarkjs | Ensure `browser-rpc/resources/snarkjs/*` is in `web_accessible_resources`   |
+| Issue                                | Fix                                                                                                      |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `Unexpected token 'export'`          | Load `content.bundle.js` from the manifest, not an ESM file                                              |
+| `must specify Extension ID`          | Pass `{ extensionID }` when starting from a web page                                                     |
+| Provider tab never opens             | Check `initializeBackground()` ran and the content script is registered                                  |
+| Proof generation fails               | Re-run `npm run reclaim-extension-setup`; check `web_accessible_resources` includes both circuit folders |
+| Assets missing after a fresh install | Run `npm run reclaim-extension-setup` again — CI often prunes `node_modules`                             |
 
----
+## Examples
 
-## Checklist
-
-- [ ] Ran `npm run reclaim-extension-setup`
-- [ ] Manifest has all required permissions and CSP
-- [ ] Added `web_accessible_resources` (including stwo and snarkjs circuits)
-- [ ] Content bundle loaded via manifest or dynamic registration
-- [ ] Background initialized with `initializeBackground()`
-- [ ] Passed `extensionID` when starting from a web page
+- [`examples/basic-extension`](examples/basic-extension) — extension popup
+- [`examples/web-app`](examples/web-app) — web page (needs `extensionID`)

--- a/src/ReclaimExtensionSDK.js
+++ b/src/ReclaimExtensionSDK.js
@@ -3,6 +3,7 @@ import { Wallet, keccak256, getBytes } from "ethers";
 import initBackground from "./background/background";
 import { BACKEND_URL, API_ENDPOINTS, RECLAIM_SDK_ACTIONS } from "./utils/constants";
 import { LOG_CONFIG_STORAGE_KEY, DEFAULT_LOG_CONFIG } from "./utils/logger/constants";
+import { withClientSource, getClientSource } from "./utils/logger/client-source";
 
 // Global verification queue to serialize extension sessions (background is single-session)
 const _verificationQueue = [];
@@ -106,7 +107,6 @@ class ReclaimExtensionProofRequest {
     const signature = await wallet.signMessage(getBytes(hash));
     instance.signature = signature;
 
-    // Init session on backend
     const initRes = await instance._initSession({
       providerId,
       appId: applicationId,
@@ -205,7 +205,6 @@ class ReclaimExtensionProofRequest {
     this._listeners[event].delete(cb);
   }
 
-  // Public API: start verification
   async startVerification() {
     return _enqueueVerification(() => this._startVerificationInternal());
   }
@@ -335,7 +334,7 @@ class ReclaimExtensionProofRequest {
   async _initSession(payload) {
     const res = await fetch(`${BACKEND_URL}/api/sdk/init/session/`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: withClientSource({ "Content-Type": "application/json" }),
       body: JSON.stringify(payload),
     });
     const data = await res.json().catch(() => ({}));
@@ -397,7 +396,6 @@ class ReclaimExtensionSDK {
     }
   }
 
-  // Check if extension is installed and matches extensionID
   isExtensionInstalled({ extensionID, timeout = 500 } = {}) {
     return new Promise((resolve) => {
       const messageId = `reclaim-check-${Date.now()}`;
@@ -427,6 +425,20 @@ class ReclaimExtensionSDK {
     return SDK_VERSION;
   }
 
+  /**
+   * The SDK's `reclaim-api-client` identity string, e.g.
+   * `browser-extension-sdk sdk/v0.4.2 (chrome/141,<ext-id>/v1.0.0)`.
+   *
+   * This is the same value sent as the `reclaim-api-client` request header and
+   * as `source` on every log entry — exposed so a consumer can quote it in a
+   * bug report, and so support can match a report to a log stream.
+   *
+   * @returns {string}
+   */
+  getClientSource() {
+    return getClientSource();
+  }
+
   // Primary API: create a per-request instance
   async init(applicationId, appSecret, providerId, options = {}) {
     // If logConfig is provided, apply it FIRST before any other operations
@@ -449,8 +461,25 @@ class ReclaimExtensionSDK {
   }
 
   /**
-   * Set log configuration
-   * @param {Object} config - Log config { logLevel: "INFO"|"DEBUG", consoleEnabled: boolean }
+   * Set log configuration.
+   *
+   * @param {Object} config - `{ logLevel, consoleEnabled }`
+   *
+   *   `logLevel` is the single threshold, governing the console and the remote
+   *   endpoint together:
+   *     "SEVERE" | "WARNING" | "INFO" (default) — values are REDACTED
+   *     "FINE"                                  — values are RAW
+   *
+   *   FINE sends response bodies, extracted parameter values, the full claim
+   *   (owner private key, session cookies) and the full proof to Reclaim's
+   *   logging endpoint. Turn it on for a specific debugging session, with the
+   *   user's knowledge — not as a standing setting.
+   *
+   *   The pre-rename spellings ERROR / WARN / DEBUG are still accepted.
+   *
+   *   `consoleEnabled` is independent and only mirrors lines to this context's
+   *   console; it never changes what is collected.
+   *
    * @param {string} extensionID - Required in web mode to route config to extension
    * @param {number} timeout - Timeout in ms (default 2000)
    * @returns {Promise<boolean>} Resolves true when config is applied, false on timeout

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,4 +1,3 @@
-// Import polyfills
 import "../utils/polyfills";
 
 // Import necessary utilities and libraries
@@ -12,14 +11,80 @@ import { removeCspStrippingRule } from "./cspRuleManager";
 import { generateProof, formatProof } from "../utils/proof-generator";
 import { createClaimObject } from "../utils/claim-creator";
 import { loggingHub } from "../utils/logger/LoggingHub";
+import { EVENT_TYPES } from "../utils/logger/constants";
 import { SessionTimerManager } from "../utils/session-timer";
 import { installOffscreenReadyListener } from "../utils/offscreen-manager";
+import { claimProgress } from "../utils/claim-progress";
 
 import * as messageRouter from "./messageRouter";
 import * as sessionManager from "./sessionManager";
+
 import * as tabManager from "./tabManager";
 import * as proofQueue from "./proofQueue";
 import * as cookieUtils from "./cookieUtils";
+
+/**
+ * Which link of the extraction chain failed -> how to report it.
+ *
+ * Spelled to match the InApp SDK's claim_creation.dart, which emits the same
+ * four names at the same severities, so one query covers both SDKs. xPath and
+ * jsonPath are errors — a selector that cannot find its element is almost always
+ * a provider that upstream changed. A regex miss and an unsatisfied
+ * responseMatch are warnings: on a page that is still loading they are the
+ * normal intermediate state, and polling may well resolve them.
+ */
+const EXTRACTION_FAILURE_REPORTS = {
+  xPath: { level: "error", eventType: EVENT_TYPES.X_PATH_MATCH_REQUIREMENT_FAILED },
+  jsonPath: { level: "error", eventType: EVENT_TYPES.JSON_PATH_MATCH_REQUIREMENT_FAILED },
+  regex: { level: "warn", eventType: EVENT_TYPES.REGEX_MATCH_REQUIREMENT_FAILED },
+  responseMatch: { level: "warn", eventType: EVENT_TYPES.NO_RESPONSE_MATCH_WARNING },
+};
+
+/**
+ * Say why the matched request did not yield a claim.
+ *
+ * Only ever reached for a request the content-script gate already matched, so
+ * this is the "we found your request but could not read it" report, not
+ * per-request noise.
+ *
+ * The response content the stage was looking at goes in the log PAYLOAD, never
+ * in the message: the payload path gives the console the full value and the
+ * endpoint a redacted, capped one. Interpolating it into the message published
+ * the user's authenticated page content to the diagnostic endpoint.
+ *
+ * Repeats are demoted to debug. The content script re-polls every
+ * NETWORK_FILTERING_INTERVAL_MS, so an unresolvable redaction is retried for the
+ * lifetime of the session timer; without this, one stuck provider would emit the
+ * same error ~30 times per session.
+ *
+ * @param {Object} ctx
+ * @param {Error & {stage?: string, element?: string}} error
+ * @param {Object} criteria - the matched requestData entry
+ */
+function reportExtractionFailure(ctx, error, criteria) {
+  const stage = error?.stage || "redaction";
+  const report = EXTRACTION_FAILURE_REPORTS[stage];
+
+  const message =
+    `[BACKGROUND] Matched request could not be extracted (${stage}) for request hash ` +
+    `${criteria?.requestHash}, will retry on a later response: ${error.message}`;
+
+  const key = `${criteria?.requestHash}|${stage}|${error.message}`;
+  const firstTime = !ctx.reportedExtractionFailures.has(key);
+  ctx.reportedExtractionFailures.add(key);
+
+  if (!report) {
+    // Unclassified: keep the pre-existing level and event so nothing regresses.
+    loggingHub.info(message, "background.claim", { eventType: EVENT_TYPES.NO_PARAMETERS_FOUND });
+    return;
+  }
+
+  const payload = error.element === undefined ? undefined : { element: error.element };
+  loggingHub[firstTime ? report.level : "debug"](message, "background.claim", {
+    eventType: report.eventType,
+    payload,
+  });
+}
 
 export default function initBackground() {
   installOffscreenReadyListener();
@@ -43,6 +108,10 @@ export default function initBackground() {
     providerRequestsByHash: new Map(),
     generatedProofs: new Map(),
     filteredRequests: new Map(),
+    // Extraction failures already reported this session, so a re-polled request
+    // does not repeat the same error at full severity. See
+    // reportExtractionFailure().
+    reportedExtractionFailures: new Set(),
     proofGenerationQueue: [],
     isProcessingQueue: false,
     firstRequestReceived: false,
@@ -50,7 +119,6 @@ export default function initBackground() {
     providerDataMessage: new Map(),
     activeSessionId: null,
     _cspRuleId: null,
-    // Timer
     sessionTimerManager: new SessionTimerManager(),
     // Constants and dependencies
     fetchProviderData,
@@ -59,10 +127,10 @@ export default function initBackground() {
     RECLAIM_SESSION_STATUS,
     MESSAGE_ACTIONS,
     MESSAGE_SOURCES,
+    EVENT_TYPES,
     generateProof,
     formatProof,
     createClaimObject,
-    // Logging hub
     loggingHub,
     // Methods to be set below
     processFilteredRequest: null,
@@ -78,6 +146,9 @@ export default function initBackground() {
   // Bind sessionManager methods to context
   ctx.failSession = (...args) => sessionManager.failSession(ctx, ...args);
   ctx.submitProofs = (...args) => sessionManager.submitProofs(ctx, ...args);
+  // Bound rather than imported: proofQueue is a set of free functions taking
+  // ctx first and importing nothing from here, so this is how it reaches it.
+  ctx.claimProgress = () => claimProgress(ctx);
 
   // Add processFilteredRequest to context (move from class)
   ctx.processFilteredRequest = async function (request, criteria, sessionId, loginUrl) {
@@ -95,6 +166,7 @@ export default function initBackground() {
       loggingHub.info(
         `[BACKGROUND] Filtering request for request hash: ${criteria.requestHash}`,
         "background.filter",
+        { eventType: EVENT_TYPES.REQUEST_MATCHED },
       );
 
       let topLevelUrl;
@@ -133,12 +205,15 @@ export default function initBackground() {
         action: ctx.MESSAGE_ACTIONS.CLAIM_CREATION_REQUESTED,
         source: ctx.MESSAGE_SOURCES.BACKGROUND,
         target: ctx.MESSAGE_SOURCES.CONTENT_SCRIPT,
-        data: { requestHash: criteria.requestHash },
+        // progress is session-wide; the popup's own counters reset on every
+        // navigation. See claimProgress().
+        data: { requestHash: criteria.requestHash, progress: claimProgress(ctx) },
       });
 
       loggingHub.info(
         "[BACKGROUND] Claim creation requested for request hash: " + criteria.requestHash,
         "background.claim",
+        { eventType: EVENT_TYPES.STARTING_CLAIM_CREATION },
       );
 
       let claimData = null;
@@ -158,9 +233,23 @@ export default function initBackground() {
           ctx.context,
         );
       } catch (error) {
+        // A redaction that doesn't resolve against *this* response is not a
+        // failure — the page usually just hasn't rendered the data yet. Report
+        // it as retryable so the content script keeps polling, and leave the
+        // session (and the popup) alone.
+        //
+        // This path exists because the authoritative xPath/jsonPath resolution
+        // moved here from the content-script gate; before, a non-matching
+        // response was simply never forwarded.
+        if (error?.retryable) {
+          reportExtractionFailure(ctx, error, criteria);
+          return { success: false, retryable: true, error: error.message };
+        }
+
         loggingHub.error(
           "[BACKGROUND] Error creating claim object: " + error.message,
           "background.claim",
+          { eventType: EVENT_TYPES.CLAIM_PARAMETER_VALIDATION_FAILED_EXCEPTION },
         );
         chrome.tabs.sendMessage(ctx.activeTabId, {
           action: ctx.MESSAGE_ACTIONS.CLAIM_CREATION_FAILED,
@@ -183,6 +272,7 @@ export default function initBackground() {
         loggingHub.info(
           "[BACKGROUND] Claim Object creation successful for request hash: " + criteria.requestHash,
           "background.claim",
+          { eventType: EVENT_TYPES.CLAIM_CREATION_STARTED },
         );
       }
       const providerRequest = {
@@ -209,14 +299,16 @@ export default function initBackground() {
       loggingHub.error(
         "[BACKGROUND] Error processing filtered request: " + error.message,
         "background.filter",
+        { eventType: EVENT_TYPES.FILTER_REQUEST_ERROR },
       );
       ctx.failSession("Error processing request: " + error.message, criteria.requestHash);
       return { success: false, error: error.message };
     }
   };
 
-  // Set up session timer callbacks
-  ctx.sessionTimerManager.setCallbacks(ctx.failSession);
+  ctx.sessionTimerManager.setCallbacks((message, requestHash) =>
+    ctx.failSession(message, requestHash, EVENT_TYPES.CLAIM_CREATION_TIMED_OUT_EXCEPTION),
+  );
   ctx.sessionTimerManager.setTimerDuration(30000);
   // Register message handler
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -236,7 +328,9 @@ export default function initBackground() {
     if (ctx.activeSessionId && (lostActive || noManagedLeft) && !ctx.aborted) {
       ctx.aborted = true;
       try {
-        loggingHub.error("[BACKGROUND] Verification tab closed by user", "background.tab");
+        loggingHub.error("[BACKGROUND] Verification tab closed by user", "background.tab", {
+          eventType: EVENT_TYPES.RECLAIM_VERIFICATION_DISMISSED,
+        });
         await ctx.failSession("Verification tab closed by user");
       } catch {}
     }

--- a/src/background/cookieUtils.js
+++ b/src/background/cookieUtils.js
@@ -259,7 +259,6 @@ export function shouldIncludeCookie(cookie, urlObj, loggingHub) {
       return false;
     }
 
-    // Check if cookie is expired
     if (cookie.expirationDate && cookie.expirationDate < Date.now() / 1000) {
       return false;
     }

--- a/src/background/messageRouter.js
+++ b/src/background/messageRouter.js
@@ -2,15 +2,37 @@
 // Handles chrome.runtime.onMessage and routes actions to modules
 
 import { loggingHub } from "../utils/logger/LoggingHub";
+import { EVENT_TYPES } from "../utils/logger/constants";
+import { DEFAULT_INJECTION_TYPE } from "../utils/provider-normalization";
 import * as sessionManager from "./sessionManager";
+import { MESSAGE_ACTIONS } from "../utils/constants/interfaces";
+
+/**
+ * Offscreen replies that have their own one-shot listener. They still pass
+ * through this router, so the default case must recognise them instead of
+ * reporting them as unsupported actions.
+ */
+const OFFSCREEN_REPLY_ACTIONS = new Set([
+  MESSAGE_ACTIONS.GET_PRIVATE_KEY_RESPONSE,
+  MESSAGE_ACTIONS.GENERATE_PROOF_RESPONSE,
+]);
 
 export async function handleMessage(ctx, message, sender, sendResponse) {
   const { action, source, target, data } = message;
 
   try {
-    // Handle LOG_MESSAGE action from content/offscreen
+    // Handle LOG_MESSAGE action from content/offscreen.
+    // data.source ("content" | "offscreen") is forwarded too — without it every
+    // remote log is indistinguishable from a background one once it reaches the
+    // hub, which makes a multi-context flow impossible to follow.
     if (action === ctx.MESSAGE_ACTIONS.LOG_MESSAGE) {
-      ctx.loggingHub.handleRemoteLog(data.message, data.type, data.level || "INFO");
+      ctx.loggingHub.handleRemoteLog(
+        data.message,
+        data.type,
+        data.level || "INFO",
+        data.source || source,
+        data.options,
+      );
       sendResponse({ success: true });
       return true;
     }
@@ -38,7 +60,7 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
               target: ctx.MESSAGE_SOURCES.CONTENT_SCRIPT,
               data: {
                 shouldInitialize: isManaged,
-                injectionType: ctx.providerData?.injectionType || null,
+                injectionType: ctx.providerData?.injectionType || DEFAULT_INJECTION_TYPE,
               },
             })
             .catch((err) =>
@@ -115,11 +137,22 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
             ctx.sessionId &&
             ctx.callbackUrl !== undefined // allow empty string as optional
           ) {
+            // Identifiers and shape, not the whole document. A provider's
+            // requestData is tens of kilobytes and its custom injection can be
+            // far larger; logging it whole is what forced the backend to split
+            // oversized entries in the first place.
             loggingHub.info(
-              "[BACKGROUND] Sending the following provider data to content script: " +
-                JSON.stringify(ctx.providerData),
+              "[BACKGROUND] Sending provider data to content script: " +
+                `${ctx.providerData?.httpProviderId || ctx.providerId} ` +
+                `(${ctx.providerData?.name || "unnamed"}), ` +
+                `${ctx.providerData?.requestData?.length ?? 0} request(s)`,
               "background.provider",
             );
+            // The object, not a string: the hub prints it in full to the
+            // console and redacts it on the way to the endpoint.
+            loggingHub.debug("[BACKGROUND] Provider data:", "background.provider", {
+              payload: ctx.providerData,
+            });
 
             sendResponse({
               success: true,
@@ -157,7 +190,7 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
           sendResponse({
             success: true,
             isManaged,
-            injectionType: ctx.providerData?.injectionType || null,
+            injectionType: ctx.providerData?.injectionType || DEFAULT_INJECTION_TYPE,
           });
         }
         break;
@@ -166,7 +199,6 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
           source === ctx.MESSAGE_SOURCES.CONTENT_SCRIPT &&
           target === ctx.MESSAGE_SOURCES.BACKGROUND
         ) {
-          // Set session context in the logging hub
           ctx.loggingHub.setSessionContext({
             sessionId: data.sessionId,
             providerId: data.providerId,
@@ -176,11 +208,13 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
           loggingHub.info(
             "Starting new verification using Reclaim Extension SDK",
             "background.verification",
+            { eventType: EVENT_TYPES.IS_RECLAIM_EXTENSION_SDK },
           );
 
           loggingHub.info(
-            "[BACKGROUND] Starting new verification flow with data: " + JSON.stringify(data),
+            "[BACKGROUND] Starting new verification flow with data:",
             "background.verification",
+            { eventType: EVENT_TYPES.VERIFICATION_FLOW_STARTED, payload: data },
           );
 
           // Concurrency guard
@@ -332,6 +366,14 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
               data.sessionId,
               data.loginUrl,
             );
+            // Un-memoize a retryable reject, otherwise the early-return above
+            // would answer every later (possibly matching) response for this
+            // hash from the cached miss.
+            if (result?.retryable) {
+              ctx.filteredRequests.delete(data.criteria.requestHash);
+              sendResponse({ success: false, retryable: true, error: result.error });
+              break;
+            }
             loggingHub.info(
               "[BACKGROUND] Filtered request processed with hash: " + data.criteria.requestHash,
               "background.filter",
@@ -366,10 +408,14 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
         break;
       case ctx.MESSAGE_ACTIONS.UPDATE_PUBLIC_DATA:
         if (sender.tab?.id && ctx.managedTabs.has(sender.tab.id)) {
-          loggingHub.info(
-            "[BACKGROUND] Updating public data: " + data?.publicData,
-            "background.data",
-          );
+          // Whatever the provider's script scraped off the page — the user's
+          // name, balance, account id. Concatenating it into the message put it
+          // past redaction entirely, because redaction cannot reach inside a
+          // string that was already built at the call site. It travels as a
+          // payload so the level decides: blanked at INFO, raw at FINE.
+          loggingHub.info("[BACKGROUND] Updating public data", "background.data", {
+            payload: { publicData: data?.publicData },
+          });
           ctx.publicData = typeof data?.publicData === "string" ? data.publicData : null;
           sendResponse({ success: true });
         } else {
@@ -412,7 +458,17 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
       }
       case ctx.MESSAGE_ACTIONS.GET_PARAMETERS:
         if (sender.tab?.id && ctx.managedTabs.has(sender.tab.id)) {
-          loggingHub.info("[BACKGROUND] Getting parameters: " + ctx.parameters, "background.data");
+          // Key names only. `ctx.parameters` is an object, so concatenating it
+          // logged the literal "[object Object]" — and would have logged the
+          // user's values had it ever been a string.
+          //
+          // FINE, not INFO: a provider script can call getParametersSync() on
+          // every render, and content.js logs "[Content] Parameters get" for
+          // the same event. Two lines per call, saying only that the page asked
+          // for parameters it was given at session start.
+          loggingHub.debug("[BACKGROUND] Getting parameters", "background.data", {
+            payload: { parameters: ctx.parameters || {} },
+          });
           sendResponse({ success: true, parameters: ctx.parameters || {} });
         } else {
           loggingHub.error(
@@ -463,6 +519,7 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
             loggingHub.info(
               "[BACKGROUND] Request claim processed: " + data.requestHash,
               "background.claim",
+              { eventType: EVENT_TYPES.PROVIDER_SCRIPT_REQUESTED_CLAIM },
             );
 
             sendResponse({ success: true, result });
@@ -470,6 +527,7 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
             loggingHub.error(
               "[BACKGROUND] Request claim processing failed: " + e?.message,
               "background.claim",
+              { eventType: EVENT_TYPES.CLAIM_PARAMETER_VALIDATION_FAILED_EXCEPTION },
             );
             sendResponse({ success: false, error: e?.message || String(e) });
           }
@@ -477,6 +535,7 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
           loggingHub.error(
             "[BACKGROUND] REQUEST_CLAIM: Tab is not managed by extension",
             "background.claim",
+            { eventType: EVENT_TYPES.TAB_NOT_MANAGED_BY_EXTENSION_EXCEPTION },
           );
           sendResponse({ success: false, error: "Tab is not managed by extension" });
         }
@@ -570,10 +629,14 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
               });
 
               const result = results?.[0]?.result;
-              loggingHub.info(
-                "[BACKGROUND] RUN_CUSTOM_INJECTION result: " + JSON.stringify(result),
-                "background.injection",
-              );
+              // A provider's injection can return whatever it likes, including
+              // scraped page values under key names redaction has never heard
+              // of. Nesting it under `injectionResult` — an opaque key — blanks
+              // the whole thing at INFO instead of walking into an object whose
+              // shape we do not control. Raw at FINE.
+              loggingHub.info("[BACKGROUND] RUN_CUSTOM_INJECTION result", "background.injection", {
+                payload: { injectionResult: result },
+              });
               sendResponse({ success: true, result });
               break;
             }
@@ -590,7 +653,21 @@ export async function handleMessage(ctx, message, sender, sendResponse) {
         break;
       }
       default: {
-        loggingHub.error("[BACKGROUND] DEFAULT: Action not supported", "background.message");
+        // The offscreen document's replies are consumed by the dedicated
+        // one-shot listeners in claim-creator / proof-generator, but this router
+        // sees every chrome.runtime message, so they reach the default case too.
+        // Reporting them as errors made every SUCCESSFUL session carry two
+        // ERROR lines — noise that hides the real ones. They are answered by
+        // their own listener, so this must not sendResponse either.
+        if (OFFSCREEN_REPLY_ACTIONS.has(action)) {
+          break;
+        }
+        // Name the action: "Action not supported" with no action is not
+        // diagnosable from the logs, which is the whole point of logging it.
+        loggingHub.error(
+          `[BACKGROUND] DEFAULT: Action not supported: ${action}`,
+          "background.message",
+        );
         sendResponse({ success: false, error: "Action not supported" });
       }
     }

--- a/src/background/proofQueue.js
+++ b/src/background/proofQueue.js
@@ -11,10 +11,12 @@ export function addToProofGenerationQueue(ctx, claimData, requestHash) {
 }
 
 export async function processNextQueueItem(ctx) {
-  const { loggingHub } = ctx;
+  const { loggingHub, EVENT_TYPES } = ctx;
 
   if (ctx.aborted) {
-    loggingHub.info("[BACKGROUND] Proof generation queue aborted", "background.proofQueue");
+    loggingHub.info("[BACKGROUND] Proof generation queue aborted", "background.proofQueue", {
+      eventType: EVENT_TYPES.CLAIM_CREATION_CANCELLED_EXCEPTION,
+    });
     return;
   }
 
@@ -51,7 +53,9 @@ export async function processNextQueueItem(ctx) {
 
   try {
     if (ctx.aborted) {
-      loggingHub.info("[BACKGROUND] Proof generation aborted", "background.proofQueue");
+      loggingHub.info("[BACKGROUND] Proof generation aborted", "background.proofQueue", {
+        eventType: EVENT_TYPES.CLAIM_CREATION_CANCELLED_EXCEPTION,
+      });
       return;
     }
 
@@ -65,6 +69,7 @@ export async function processNextQueueItem(ctx) {
     loggingHub.info(
       "[BACKGROUND] Proof generation started for request hash: " + task.requestHash,
       "background.proofQueue",
+      { eventType: EVENT_TYPES.PROOF_GENERATION_STARTED },
     );
 
     const proofResponseObject = await ctx.generateProof(
@@ -76,7 +81,9 @@ export async function processNextQueueItem(ctx) {
     );
 
     if (ctx.aborted) {
-      loggingHub.info("[BACKGROUND] Proof generation aborted", "background.proofQueue");
+      loggingHub.info("[BACKGROUND] Proof generation aborted", "background.proofQueue", {
+        eventType: EVENT_TYPES.CLAIM_CREATION_CANCELLED_EXCEPTION,
+      });
       return;
     }
 
@@ -87,6 +94,7 @@ export async function processNextQueueItem(ctx) {
           ": " +
           proofResponseObject.error,
         "background.proofQueue",
+        { eventType: EVENT_TYPES.PROOF_GENERATION_FAILED_EXCEPTION },
       );
       ctx.failSession("Proof generation failed: " + proofResponseObject.error, task.requestHash);
       return;
@@ -102,27 +110,35 @@ export async function processNextQueueItem(ctx) {
       loggingHub.info(
         "[BACKGROUND] Proof generation successful for request hash: " + task.requestHash,
         "background.proofQueue",
+        { eventType: EVENT_TYPES.PROOF_GENERATED },
       );
 
       chrome.tabs.sendMessage(ctx.activeTabId, {
         action: ctx.MESSAGE_ACTIONS.PROOF_GENERATION_SUCCESS,
         source: ctx.MESSAGE_SOURCES.BACKGROUND,
         target: ctx.MESSAGE_SOURCES.CONTENT_SCRIPT,
-        data: { requestHash: task.requestHash },
+        // Sent after generatedProofs is updated above, so `completed` counts
+        // this proof. The popup cannot derive it — see claimProgress().
+        data: { requestHash: task.requestHash, progress: ctx.claimProgress?.() },
       });
 
       ctx.sessionTimerManager.resetSessionTimer();
     }
   } catch (error) {
+    // Not every rejection down this path is an Error: the offscreen bridge used
+    // to reject a bare `{success, error}` literal, which made this line — the
+    // session's only explanation of a proof failure — read "…: undefined", and
+    // put that same string on the consumer's Promise. Fixed at the source, but
+    // read both shapes so the next plain-object rejection is still legible.
+    const reason = error?.message || error?.error || String(error);
+
     loggingHub.error(
-      "[BACKGROUND] Proof generation failed for request hash: " +
-        task.requestHash +
-        ": " +
-        error?.message,
+      "[BACKGROUND] Proof generation failed for request hash: " + task.requestHash + ": " + reason,
       "background.proofQueue",
+      { eventType: EVENT_TYPES.PROOF_GENERATION_FAILED_EXCEPTION },
     );
 
-    ctx.failSession("Proof generation failed: " + error.message, task.requestHash);
+    ctx.failSession("Proof generation failed: " + reason, task.requestHash);
     return;
   } finally {
     ctx.isProcessingQueue = false;

--- a/src/background/sessionManager.js
+++ b/src/background/sessionManager.js
@@ -2,6 +2,8 @@
 // Handles session start, fail, submit, and timer logic
 
 import { loggingHub } from "../utils/logger/LoggingHub";
+import { EVENT_TYPES } from "../utils/logger/constants";
+import { normalizeInjectionType } from "../utils/provider-normalization";
 import { addCspStrippingRule, removeCspStrippingRule } from "./cspRuleManager";
 import { CSP_RULE_MAX_LIFETIME_MS, TAB_TRANSITION_DELAY_MS } from "../utils/constants/config";
 
@@ -17,22 +19,20 @@ export async function startVerification(ctx, templateData) {
     ctx.callbackUrl = null;
     ctx.generatedProofs = new Map();
     ctx.filteredRequests = new Map();
+    ctx.reportedExtractionFailures = new Set();
     ctx.initPopupMessage = new Map();
     ctx.providerDataMessage = new Map();
     ctx.providerRequestsByHash = new Map();
     ctx.aborted = false;
     ctx._cspRuleId = null;
 
-    // Reset timers and timer state variables
     ctx.sessionTimerManager.clearAllTimers();
     ctx.firstRequestReceived = false;
 
-    // fetch provider data
     if (!templateData.providerId) {
       throw new Error("Provider ID not found");
     }
 
-    // Set session context in the logging hub
     ctx.loggingHub.setSessionContext({
       sessionId: templateData.sessionId,
       providerId: templateData.providerId,
@@ -51,7 +51,21 @@ export async function startVerification(ctx, templateData) {
       templateData.applicationId,
     );
 
+    // Coerce injectionType before anything reads it. The router hands it to
+    // the content script, which only distinguishes NONE from "inject the
+    // interceptor" — an unsupported value (MSWJS/XHOOK/CDP) would otherwise
+    // flow through unchecked.
+    if (providerData) {
+      providerData.injectionType = normalizeInjectionType(providerData.injectionType, loggingHub);
+    }
     ctx.providerData = providerData;
+
+    loggingHub.info(
+      `[BACKGROUND] Fetched provider data for ${templateData.providerId}: ` +
+        `${providerData?.name || "unnamed"}, ${providerData?.requestData?.length ?? 0} request(s)`,
+      "background.provider",
+      { eventType: EVENT_TYPES.FETCHED_PROVIDERS },
+    );
 
     ctx.providerId = templateData.providerId;
     if (templateData.parameters) {
@@ -115,12 +129,12 @@ export async function startVerification(ctx, templateData) {
     // Create a new tab with provider URL DIRECTLY - not through an async flow
     const providerUrl = providerData.loginUrl;
 
-    // Use chrome.tabs.create directly and handle the promise explicitly
     chrome.tabs.create({ url: providerUrl }, (tab) => {
       ctx.activeTabId = tab.id;
       loggingHub.info(
         `[BACKGROUND] New tab created for provider ${templateData.providerId} with tab id ${tab.id}`,
         "background.tab",
+        { eventType: EVENT_TYPES.LOADING_INITIAL_URL },
       );
 
       ctx.managedTabs.add(tab.id);
@@ -157,7 +171,6 @@ export async function startVerification(ctx, templateData) {
           },
         };
 
-        // Initialize the message map if it doesn't exist
         if (!ctx.initPopupMessage) {
           ctx.initPopupMessage = new Map();
         }
@@ -177,6 +190,7 @@ export async function startVerification(ctx, templateData) {
       loggingHub.info(
         `[BACKGROUND] Starting verification with session id: ${ctx.sessionId}`,
         "background.verification",
+        { eventType: EVENT_TYPES.USER_STARTED_VERIFICATION },
       );
 
       // Update session status after tab creation
@@ -191,6 +205,7 @@ export async function startVerification(ctx, templateData) {
           loggingHub.error(
             `[BACKGROUND] Error updating session status: ${error?.message}`,
             "background.session",
+            { eventType: EVENT_TYPES.UPDATE_SESSION_STATUS_ERROR },
           );
         });
     });
@@ -203,6 +218,7 @@ export async function startVerification(ctx, templateData) {
     loggingHub.error(
       `[BACKGROUND] Error starting verification: ${error?.message}`,
       "background.verification",
+      { eventType: EVENT_TYPES.RECLAIM_EXCEPTION },
     );
     // Clean up CSP stripping rule if it was added before the error
     if (ctx._cspRuleId) {
@@ -215,16 +231,16 @@ export async function startVerification(ctx, templateData) {
   }
 }
 
-export async function failSession(ctx, errorMessage, requestHash) {
-  loggingHub.info(`[BACKGROUND] Failing session: ${errorMessage}`, "background.session");
+export async function failSession(ctx, errorMessage, requestHash, eventType) {
+  loggingHub.info(`[BACKGROUND] Failing session: ${errorMessage}`, "background.session", {
+    eventType: eventType || EVENT_TYPES.RECLAIM_EXCEPTION,
+  });
 
-  // Clean up CSP stripping rule
   if (ctx._cspRuleId) {
     await removeCspStrippingRule().catch(() => {});
     ctx._cspRuleId = null;
   }
 
-  // Clear all timers
   ctx.sessionTimerManager.clearAllTimers();
 
   // abort immediately to stop queue/offscreen processing
@@ -248,6 +264,7 @@ export async function failSession(ctx, errorMessage, requestHash) {
       loggingHub.error(
         `[BACKGROUND] Error updating session status to failed: ${error?.message}`,
         "background.session",
+        { eventType: EVENT_TYPES.UPDATE_SESSION_STATUS_ERROR },
       );
     }
   }
@@ -269,7 +286,6 @@ export async function failSession(ctx, errorMessage, requestHash) {
       });
   }
 
-  // Also forward to the original tab
   if (ctx.originalTabId) {
     try {
       await chrome.tabs.sendMessage(ctx.originalTabId, {
@@ -291,6 +307,7 @@ export async function failSession(ctx, errorMessage, requestHash) {
     loggingHub.info(
       `[BACKGROUND] Proof generation failed, Broadcasting to popup/options pages: ${errorMessage}`,
       "background.proof",
+      { eventType: EVENT_TYPES.PROOF_GENERATION_FAILED },
     );
 
     await chrome.runtime.sendMessage({
@@ -308,8 +325,7 @@ export async function failSession(ctx, errorMessage, requestHash) {
   ctx.proofGenerationQueue = [];
   ctx.isProcessingQueue = false;
 
-  // Clear session context from logging hub
-  ctx.loggingHub.clearSessionContext();
+  await ctx.loggingHub.clearSessionContext();
 
   // Release concurrency guard
   ctx.activeSessionId = null;
@@ -366,10 +382,15 @@ export async function submitProofs(ctx) {
       publicData: ctx.publicData ?? null,
     }));
 
-    loggingHub.info(
-      `[BACKGROUND] Submitting proofs ${JSON.stringify(finalProofs)}`,
-      "background.proof",
-    );
+    // At INFO the identifier, signatures, witnesses and providerRequest survive
+    // redaction while `claimData` is blanked wholesale — the same shape the
+    // InApp SDK's own PROOF_GENERATED line has. That is deliberate: `claimData`
+    // holds `context.extractedParameters`, which is the plaintext value the user
+    // is proving, and this used to reach Loki on every successful session.
+    loggingHub.info("[BACKGROUND] Submitting proofs", "background.proof", {
+      eventType: EVENT_TYPES.SUBMITTING_PROOF,
+      payload: finalProofs,
+    });
 
     let submitted = false;
     // If callbackUrl provided, submit; otherwise just signal completion
@@ -429,6 +450,7 @@ export async function submitProofs(ctx) {
         loggingHub.error(
           `[BACKGROUND] Error submitting proofs: ${error.message}`,
           "background.proof",
+          { eventType: EVENT_TYPES.PROOF_SUBMISSION_FAILED },
         );
         throw error;
       }
@@ -439,6 +461,7 @@ export async function submitProofs(ctx) {
           loggingHub.info(
             `[BACKGROUND] Updating status to PROOF_GENERATION_SUCCESS`,
             "background.proof",
+            { eventType: EVENT_TYPES.PROOF_GENERATION_SUCCESS },
           );
           await ctx.updateSessionStatus(
             ctx.sessionId,
@@ -454,6 +477,18 @@ export async function submitProofs(ctx) {
         }
       }
     }
+
+    // Emitted once, before the notifications and independently of them. It used
+    // to ride on the activeTabId branch below, so a flow that completed after
+    // the provider tab had closed produced no PROOF_SUBMITTED event at all —
+    // the session simply stopped mid-stream in the logs. `submitted` is spelled
+    // out because with no callbackUrl nothing is posted anywhere: the proofs are
+    // handed back to the consumer, which the event name alone does not convey.
+    loggingHub.info(
+      `[BACKGROUND] Proofs ready (${finalProofs.length}), submittedToCallback=${submitted}`,
+      "background.proof",
+      { eventType: EVENT_TYPES.PROOF_SUBMITTED },
+    );
 
     // Notify content script with proofs in both cases
     if (ctx.activeTabId) {
@@ -534,21 +569,18 @@ export async function submitProofs(ctx) {
       }
     }
 
-    // Clean up CSP stripping rule
     if (ctx._cspRuleId) {
       await removeCspStrippingRule().catch(() => {});
       ctx._cspRuleId = null;
     }
 
-    // Clear session context from logging hub
-    ctx.loggingHub.clearSessionContext();
+    await ctx.loggingHub.clearSessionContext();
 
     // Release concurrency guard on success
     ctx.activeSessionId = null;
     return { success: true };
   } catch (error) {
     loggingHub.error(`[BACKGROUND] Error submitting proof: ${error?.message}`, "background.proof");
-    // Clean up CSP stripping rule on failure too
     if (ctx._cspRuleId) {
       await removeCspStrippingRule().catch(() => {});
       ctx._cspRuleId = null;
@@ -561,9 +593,10 @@ export async function submitProofs(ctx) {
 
 export async function cancelSession(ctx) {
   try {
-    loggingHub.info(`[BACKGROUND] Cancelling session`, "background.session");
+    loggingHub.info(`[BACKGROUND] Cancelling session`, "background.session", {
+      eventType: EVENT_TYPES.RECLAIM_VERIFICATION_CANCELLED_EXCEPTION,
+    });
 
-    // Clean up CSP stripping rule
     if (ctx._cspRuleId) {
       await removeCspStrippingRule().catch(() => {});
       ctx._cspRuleId = null;
@@ -616,7 +649,6 @@ export async function cancelSession(ctx) {
       }
     }
 
-    // Also forward to the original tab
     if (ctx.originalTabId) {
       try {
         loggingHub.info(
@@ -655,7 +687,6 @@ export async function cancelSession(ctx) {
       );
     }
 
-    // Close managed tab and restore original if available
     if (ctx.originalTabId) {
       try {
         setTimeout(async () => {
@@ -697,8 +728,7 @@ export async function cancelSession(ctx) {
     ctx.providerRequestsByHash = new Map();
     ctx.managedTabs.clear();
 
-    // Clear session context from logging hub
-    ctx.loggingHub.clearSessionContext();
+    await ctx.loggingHub.clearSessionContext();
 
     // Release guard
     ctx.activeSessionId = null;

--- a/src/content/components/reclaim-provider-verification-popup.css
+++ b/src/content/components/reclaim-provider-verification-popup.css
@@ -1,6 +1,10 @@
 .reclaim-popup {
   position: fixed;
-  bottom: 20px;
+  /* Lifted clear of the bottom of the page. At 20px the panel landed inside the
+     sticky bars sites like to put there — cookie notices, CTA bars, chat
+     launchers are all roughly 50-60px tall — so it overlapped them on load.
+     Only the initial position: dragging sets `top`/`left` and `bottom: auto`. */
+  bottom: 64px;
   right: 20px;
   width: 320px;
   max-height: 85vh;
@@ -74,12 +78,49 @@
   cursor: grabbing;
 }
 
+/* Drag affordance: the conventional dot-grid grabber (4x2), drawn with one tiled
+   radial gradient rather than eight elements. `margin: 0 auto` centres it in the
+   flex header without setting justify-content, so re-enabling the commented-out
+   logo and title above still lays out as it used to. */
+.reclaim-drag-handle {
+  margin: 0 auto;
+  /* Exact multiples of background-size, or the last column/row renders as a
+     clipped half-dot: 20/5 = 4 columns, 10/5 = 2 rows. */
+  width: 20px;
+  height: 10px;
+  /* Let the mousedown land on the header, matching .reclaim-popup-logo. */
+  pointer-events: none;
+  background-image: radial-gradient(
+    circle at center,
+    rgba(255, 255, 255, 0.55) 1px,
+    transparent 1.3px
+  );
+  background-size: 5px 5px;
+  transition: background-image 0.2s ease;
+}
+
+/* Brighten with the header's own hover, and hold it bright while dragging so the
+   handle reads as the thing being held. */
+.reclaim-popup-header:hover .reclaim-drag-handle,
+.reclaim-popup.dragging .reclaim-drag-handle {
+  background-image: radial-gradient(
+    circle at center,
+    rgba(255, 255, 255, 0.9) 1px,
+    transparent 1.3px
+  );
+}
+
 .reclaim-popup-content {
-  padding: 8px 18px 16px 18px;
+  /* Symmetric. The gap below the header's border was 8px while the gap under the
+     last card was 16px, which read as the panel sagging at the bottom. */
+  padding: 12px 18px 12px 18px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  min-height: 280px;
+  /* Hug the content. This used to be `center` inside a `min-height: 280px` box,
+     which was fine when the info grid filled it; with only the session id and
+     the status card left it padded the panel out with dead space. */
+  justify-content: flex-start;
+  min-height: 0;
   max-height: 400px;
   overflow-y: auto;
 }
@@ -105,29 +146,10 @@
   letter-spacing: -0.01em;
 }
 
-/* Compact info grid */
-.reclaim-info-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-bottom: 12px;
-}
-
-.reclaim-info-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px 12px;
-  background: rgba(255, 255, 255, 0.02);
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  transition: all 0.2s ease;
-}
-
-.reclaim-info-item:hover {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.08);
-}
+/* The Source / Description / Data Required grid that used to sit above the
+   session id is gone — the popup shows the session id and the verification
+   status only. `.reclaim-info-label` and `.reclaim-info-value` below are kept:
+   the session-id row still uses both. */
 
 .reclaim-info-label {
   color: rgba(255, 255, 255, 0.6);
@@ -158,18 +180,6 @@
 
 .reclaim-info-value:hover {
   color: #3b82f6;
-}
-
-.reclaim-info-value.expandable {
-  cursor: pointer;
-}
-
-.reclaim-info-value.expanded {
-  white-space: normal;
-  word-break: break-word;
-  text-overflow: clip;
-  overflow: visible;
-  max-width: none;
 }
 
 .reclaim-info-tooltip {
@@ -220,7 +230,7 @@
   background: linear-gradient(135deg, rgba(16, 185, 129, 0.08) 0%, rgba(5, 150, 105, 0.04) 100%);
   border-radius: 8px;
   border: 1px solid rgba(16, 185, 129, 0.15);
-  margin-bottom: 12px;
+  margin-bottom: 10px;
   position: relative;
 }
 
@@ -303,7 +313,9 @@
 
 /* Combined verification container */
 .reclaim-verification-container {
-  margin-bottom: 4px;
+  /* Nothing follows this container, so a bottom margin here is just trailing
+     space under the last card. */
+  margin-bottom: 0;
   transform: translateY(0);
   opacity: 1;
   will-change: transform, opacity;
@@ -397,7 +409,7 @@
   opacity: 0;
   will-change: transform, opacity;
   transition: all 0.3s ease;
-  margin-top: 12px;
+  margin-top: 10px;
   display: none;
 }
 
@@ -407,22 +419,10 @@
   display: block;
 }
 
-/* Adjust content spacing when status is visible */
-.reclaim-popup-content:has(.reclaim-status-container.visible) {
-  justify-content: flex-start;
-  padding-top: 20px;
-}
-
-/* Alternative for browsers that don't support :has() */
-.reclaim-popup-content.status-active {
-  justify-content: flex-start;
-  padding-top: 20px;
-}
-
 .reclaim-status-progress {
   display: flex;
   flex-direction: column;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
 .reclaim-progress-header {
@@ -500,7 +500,7 @@
 }
 
 .reclaim-status-message {
-  margin-top: 8px;
+  margin-top: 6px;
   font-size: 12px;
   color: rgba(255, 255, 255, 0.8);
   font-weight: 500;
@@ -535,12 +535,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 8px 0;
+  margin: 4px 0;
 }
 
 .reclaim-circular-loader svg {
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   animation: reclaim-rotate 2s linear infinite;
 }
 
@@ -635,7 +635,9 @@
 @media (max-width: 400px) {
   .reclaim-popup {
     width: calc(100% - 24px);
-    bottom: 12px;
+    /* Lifted too, but less: max-height is 90vh here, so a large bottom offset
+       would push the top of the panel off a short viewport. */
+    bottom: 24px;
     right: 12px;
     left: 12px;
     max-width: 100%;
@@ -643,7 +645,7 @@
   }
 
   .reclaim-popup-content {
-    min-height: 240px;
+    min-height: 0;
     max-height: calc(90vh - 80px);
   }
 

--- a/src/content/components/reclaim-provider-verification-popup.html
+++ b/src/content/components/reclaim-provider-verification-popup.html
@@ -1,25 +1,15 @@
-<div class="reclaim-popup-header">
+<div class="reclaim-popup-header" title="Drag to move">
   <!-- <img class="reclaim-popup-logo" src="{{logoUrl}}" alt="Reclaim Protocol" />
   <h3 class="reclaim-popup-title">Reclaim Protocol</h3> -->
+
+  <!-- The header IS the drag handle (see initializeDragFunctionality), but with
+       the logo and title commented out it renders as an empty bar, so nothing
+       told the user it could be dragged. Decorative: `aria-hidden` because the
+       `title` above already carries the hint. -->
+  <span class="reclaim-drag-handle" aria-hidden="true"></span>
 </div>
 
 <div class="reclaim-popup-content">
-  <!-- Compact info grid -->
-  <div class="reclaim-info-grid">
-    <div class="reclaim-info-item">
-      <span class="reclaim-info-label">Source</span>
-      <span class="reclaim-info-value" data-tooltip="{{providerName}}">{{providerName}}</span>
-    </div>
-    <div class="reclaim-info-item">
-      <span class="reclaim-info-label">Description</span>
-      <span class="reclaim-info-value" data-tooltip="{{description}}">{{description}}</span>
-    </div>
-    <div class="reclaim-info-item">
-      <span class="reclaim-info-label">Data Required</span>
-      <span class="reclaim-info-value" data-tooltip="{{dataRequired}}">{{dataRequired}}</span>
-    </div>
-  </div>
-
   <!-- Session ID with copy button -->
   <div class="reclaim-session-section">
     <div class="reclaim-session-content">

--- a/src/content/components/reclaim-provider-verification-popup.js
+++ b/src/content/components/reclaim-provider-verification-popup.js
@@ -25,9 +25,7 @@ export function createProviderVerificationPopup(
   let isDragging = false;
   let dragOffset = { x: 0, y: 0 };
 
-  // Create initial HTML content
   renderInitialContent().then(() => {
-    // Initialize drag and copy functionality after content is rendered
     initializeDragFunctionality();
     initializeCopyFunctionality();
     initializeTooltipFunctionality();
@@ -35,7 +33,6 @@ export function createProviderVerificationPopup(
 
   // Drag and copy functionality will be initialized after content is rendered
 
-  // Function to load CSS from external file
   async function loadCSS() {
     // Check if styles are already injected
     if (document.getElementById("reclaim-popup-styles")) {
@@ -71,7 +68,6 @@ export function createProviderVerificationPopup(
     }
   }
 
-  // Function to load HTML template from external file
   async function loadHTMLTemplate() {
     try {
       const htmlUrl = chrome.runtime.getURL(
@@ -86,12 +82,10 @@ export function createProviderVerificationPopup(
     }
   }
 
-  // Function to inject CSS styles
   function injectStyles() {
     loadCSS();
   }
 
-  // Function to render the initial content
   async function renderInitialContent() {
     const htmlTemplate = await loadHTMLTemplate();
 
@@ -100,18 +94,21 @@ export function createProviderVerificationPopup(
       return;
     }
 
-    // Replace template placeholders with actual values
+    // Replace template placeholders with actual values.
+    //
+    // `description` and `dataRequired` no longer appear in the template — the
+    // popup shows the session id and the verification status only. They stay in
+    // the function signature because the background still sends them in
+    // SHOW_PROVIDER_VERIFICATION_POPUP, and `providerName` is still used by the
+    // "How it works" steps.
     const renderedHTML = htmlTemplate
       // .replace(/\{\{logoUrl\}\}/g, chrome.runtime.getURL("assets/img/logo.png"))
       .replace(/\{\{providerName\}\}/g, providerName)
-      .replace(/\{\{description\}\}/g, description)
-      .replace(/\{\{dataRequired\}\}/g, dataRequired)
       .replace(/\{\{sessionId\}\}/g, sessionId);
 
     popup.innerHTML = renderedHTML;
   }
 
-  // Function to initialize drag functionality
   function initializeDragFunctionality() {
     const header = popup.querySelector(".reclaim-popup-header");
 
@@ -130,7 +127,6 @@ export function createProviderVerificationPopup(
       // Prevent text selection while dragging
       e.preventDefault();
 
-      // Add global mouse event listeners
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
     }
@@ -150,7 +146,6 @@ export function createProviderVerificationPopup(
       const popupWidth = popup.offsetWidth;
       const popupHeight = popup.offsetHeight;
 
-      // Keep popup within viewport bounds
       newX = Math.max(0, Math.min(newX, viewportWidth - popupWidth));
       newY = Math.max(0, Math.min(newY, viewportHeight - popupHeight));
 
@@ -167,12 +162,10 @@ export function createProviderVerificationPopup(
       isDragging = false;
       popup.classList.remove("dragging");
 
-      // Remove global mouse event listeners
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
     }
 
-    // Add mousedown listener to header
     header.addEventListener("mousedown", handleMouseDown);
 
     // Prevent context menu on header to avoid interference
@@ -181,7 +174,6 @@ export function createProviderVerificationPopup(
     });
   }
 
-  // Function to initialize copy functionality
   function initializeCopyFunctionality() {
     const copyButton = popup.querySelector(".reclaim-copy-icon");
     const copyFeedback = popup.querySelector("#reclaim-copy-feedback");
@@ -198,7 +190,6 @@ export function createProviderVerificationPopup(
           try {
             const textToCopy = targetElement.textContent.trim();
 
-            // Use the Clipboard API if available
             if (navigator.clipboard && navigator.clipboard.writeText) {
               await navigator.clipboard.writeText(textToCopy);
               showCopyFeedback("Copied!");
@@ -250,7 +241,6 @@ export function createProviderVerificationPopup(
     }
   }
 
-  // Function to initialize tooltip functionality for long text
   function initializeTooltipFunctionality() {
     const infoValues = popup.querySelectorAll(".reclaim-info-value[data-tooltip]");
 
@@ -311,7 +301,6 @@ export function createProviderVerificationPopup(
     });
   }
 
-  // Function to show loader
   function showLoader(message = "Generating verification proof...") {
     const stepsContainer = popup.querySelector("#reclaim-steps-container");
     const statusContainer = popup.querySelector("#reclaim-status-container");
@@ -335,7 +324,6 @@ export function createProviderVerificationPopup(
       errorIcon.style.display = "none";
     }
 
-    // Show the status container using CSS classes
     statusContainer.classList.add("visible");
     contentContainer.classList.add("status-active");
     circularLoader.style.display = "flex";
@@ -346,16 +334,19 @@ export function createProviderVerificationPopup(
     updateProgressBar();
   }
 
-  // Function to update the progress bar
   function updateProgressBar() {
     const progressBar = popup.querySelector("#reclaim-progress-bar");
     const progressCounter = popup.querySelector("#reclaim-progress-counter");
 
     if (state.totalClaims > 0) {
-      const percentage = state.completedClaims / state.totalClaims;
+      // Clamped: the fallback increment path has no session-wide total to check
+      // against, and a bar scaled past 1 (or a counter reading 4/3) is worse
+      // than one that saturates.
+      const completed = Math.min(state.completedClaims, state.totalClaims);
+      const percentage = completed / state.totalClaims;
       // Use transform instead of width to avoid layout recalculations
       progressBar.style.transform = `scaleX(${percentage})`;
-      progressCounter.textContent = `${state.completedClaims}/${state.totalClaims}`;
+      progressCounter.textContent = `${completed}/${state.totalClaims}`;
     } else {
       progressBar.style.transform = "scaleX(1)";
       progressBar.style.animation = "reclaim-progress-pulse 2s infinite";
@@ -363,14 +354,12 @@ export function createProviderVerificationPopup(
     }
   }
 
-  // Function to update status message
   function updateStatusMessage(message, isError = false) {
     const statusMessage = popup.querySelector("#reclaim-status-message");
     statusMessage.textContent = message;
     statusMessage.style.color = isError ? "#ef4444" : "rgba(255, 255, 255, 0.8)";
   }
 
-  // Function to show success state
   function showSuccess() {
     const stepsContainer = popup.querySelector("#reclaim-steps-container");
     const statusContainer = popup.querySelector("#reclaim-status-container");
@@ -386,7 +375,6 @@ export function createProviderVerificationPopup(
       stepsContainer.classList.add("hidden");
     }
 
-    // Hide circular loader
     circularLoader.style.display = "none";
 
     // Show success UI
@@ -412,7 +400,6 @@ export function createProviderVerificationPopup(
 
     updateStatusMessage("You will be redirected to the original page shortly.");
 
-    // Show success icon
     const successIcon = popup.querySelector("#reclaim-success-icon");
     const errorIcon = popup.querySelector("#reclaim-error-icon");
     if (successIcon) {
@@ -423,7 +410,6 @@ export function createProviderVerificationPopup(
     }
   }
 
-  // Function to show error state
   function showError(errorMessage) {
     const stepsContainer = popup.querySelector("#reclaim-steps-container");
     const statusContainer = popup.querySelector("#reclaim-status-container");
@@ -438,7 +424,6 @@ export function createProviderVerificationPopup(
       stepsContainer.classList.add("hidden");
     }
 
-    // Hide circular loader
     circularLoader.style.display = "none";
 
     // Show error UI
@@ -452,7 +437,6 @@ export function createProviderVerificationPopup(
 
     updateStatusMessage(errorMessage, true);
 
-    // Show error icon
     const errorIcon = popup.querySelector("#reclaim-error-icon");
     const successIcon = popup.querySelector("#reclaim-success-icon");
     if (errorIcon) {
@@ -463,15 +447,37 @@ export function createProviderVerificationPopup(
     }
   }
 
-  // Function to increment the total claims count
   function incrementTotalClaims() {
     state.totalClaims += 1;
     updateProgressBar();
   }
 
-  // Function to increment the completed claims count
   function incrementCompletedClaims() {
     state.completedClaims += 1;
+    updateProgressBar();
+  }
+
+  /**
+   * Adopt the background's session-wide counts, when it sends them.
+   *
+   * This popup is rebuilt from zero on every navigation, and a multi-request
+   * provider spans several origins — so the local counters only ever describe
+   * the current page. The background's numbers span the whole session.
+   *
+   * Falls back to the local increment when `progress` is absent, so an older
+   * message shape (or a path that has not been given the counts) still moves
+   * the bar rather than freezing it.
+   *
+   * @param {{completed: number, total: number}|undefined} progress
+   * @param {() => void} fallback
+   */
+  function applyProgress(progress, fallback) {
+    if (!progress || typeof progress.total !== "number") {
+      fallback();
+      return;
+    }
+    state.totalClaims = progress.total;
+    state.completedClaims = Math.min(progress.completed ?? 0, progress.total);
     updateProgressBar();
   }
 
@@ -486,8 +492,8 @@ export function createProviderVerificationPopup(
     incrementCompletedClaims,
 
     // Handle various status updates from background
-    handleClaimCreationRequested: (requestHash) => {
-      incrementTotalClaims();
+    handleClaimCreationRequested: (requestHash, progress) => {
+      applyProgress(progress, incrementTotalClaims);
       showLoader("Creating verification claim...");
     },
 
@@ -503,8 +509,8 @@ export function createProviderVerificationPopup(
       updateStatusMessage("Generating cryptographic proof...");
     },
 
-    handleProofGenerationSuccess: (requestHash) => {
-      incrementCompletedClaims();
+    handleProofGenerationSuccess: (requestHash, progress) => {
+      applyProgress(progress, incrementCompletedClaims);
       updateStatusMessage(`Proof generated (${state.completedClaims}/${state.totalClaims})`);
     },
 

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -1,20 +1,28 @@
-// Import polyfills
 import "../utils/polyfills";
 
 import { RECLAIM_SDK_ACTIONS, MESSAGE_ACTIONS, MESSAGE_SOURCES } from "../utils/constants";
 import { createProviderVerificationPopup } from "./components/reclaim-provider-verification-popup";
-import { filterRequest } from "../utils/claim-creator";
+// Imported from the module directly, not the ../utils/claim-creator barrel: the
+// barrel also re-exports params-extractor, which pulls in the vendored attestor
+// parsers (xpath/parse5/esprima). Those have import-time side effects
+// (patch-parse5-tree mutates domhandler prototypes), so webpack cannot shake
+// them out — and this bundle is injected at document_start on every page.
+import {
+  describeRequestMatch,
+  MATCH_STAGES,
+  MATCH_STAGE_ORDER,
+} from "../utils/claim-creator/network-filter";
 import { createRemoteLogger } from "../utils/logger/RemoteLogger";
-import { LOG_CONFIG_STORAGE_KEY } from "../utils/logger/constants";
+import { LOG_CONFIG_STORAGE_KEY, EVENT_TYPES } from "../utils/logger/constants";
 import {
   NETWORK_FILTERING_TIMEOUT_MS,
   NETWORK_FILTERING_INTERVAL_MS,
   INTERCEPTED_DATA_MAX_AGE_MS,
+  SESSION_TIMER_DURATION_MS,
 } from "../utils/constants/config";
 
 const logger = createRemoteLogger("content");
 
-// Create a flag to track if we should initialize
 let shouldInitialize = false;
 let interceptorInjected = false;
 let injectionScriptInjected = false;
@@ -260,7 +268,6 @@ class ReclaimContentScript {
     this.credentialType = null;
     this.dataRequired = null;
 
-    // Storage for intercepted requests and responses
     this.interceptedRequestResponses = new Map();
 
     // Filtering state
@@ -274,6 +281,14 @@ class ReclaimContentScript {
     this.filteredRequests = [];
     this.isFiltering = false;
     this.stopStoringInterceptions = false;
+
+    // Match diagnostics. `matchProgress` maps "<matcherIndex>|<requestKey>" to
+    // the furthest MATCH_STAGE_ORDER index that pair ever reached; filtering
+    // re-runs every NETWORK_FILTERING_INTERVAL_MS over the same request map, so
+    // logging on every evaluation would repeat each verdict for the life of the
+    // session. Only an *advance* is reported.
+    this.matchProgress = new Map();
+    this.noMatchTimer = null;
 
     // Flag to track if this is a managed tab (will be set during init)
     this.isManagedTab = false;
@@ -303,12 +318,49 @@ class ReclaimContentScript {
     }
   }
 
+  /**
+   * Push the log config down into the page world.
+   *
+   * The MAIN-world bridge cannot read chrome.storage, so without this its
+   * console mirroring would ignore `consoleEnabled` entirely — which is how the
+   * interceptor ended up logging on every page regardless of configuration.
+   * Called once at init and again whenever the stored config changes.
+   */
+  pushLogConfigToPage(config) {
+    if (config) this._lastLogConfig = config;
+    try {
+      window.postMessage({ action: RECLAIM_SDK_ACTIONS.LOG_CONFIG, data: { config } }, "*");
+    } catch {
+      // Nothing to do: the bridge falls back to its permissive defaults.
+    }
+  }
+
+  /**
+   * Keep the page world in sync with the stored log config.
+   */
+  watchLogConfig() {
+    try {
+      chrome.storage.local.get(LOG_CONFIG_STORAGE_KEY, (stored) => {
+        const config = stored?.[LOG_CONFIG_STORAGE_KEY];
+        if (config) this.pushLogConfigToPage(config);
+      });
+      chrome.storage.onChanged.addListener((changes, area) => {
+        if (area === "local" && changes[LOG_CONFIG_STORAGE_KEY]?.newValue) {
+          this.pushLogConfigToPage(changes[LOG_CONFIG_STORAGE_KEY].newValue);
+        }
+      });
+    } catch {
+      // Storage unavailable in this context.
+    }
+  }
+
   init() {
     if (!shouldInitialize) {
       return;
     }
 
     chrome.runtime.onMessage.addListener(this.handleMessage.bind(this));
+    this.watchLogConfig();
 
     // First verify this is a managed tab before proceeding with initialization
     chrome.runtime.sendMessage(
@@ -325,7 +377,6 @@ class ReclaimContentScript {
           return;
         }
 
-        // Mark this as a managed tab
         this.isManagedTab = true;
 
         // Only proceed with provider data request if this is a managed tab
@@ -349,7 +400,6 @@ class ReclaimContentScript {
                 "content.provider",
               );
 
-              // Trigger one-time page fetch if replay is allowed
               if (!this.providerData?.disableRequestReplay) {
                 chrome.runtime.sendMessage({
                   action: MESSAGE_ACTIONS.INJECT_VIA_SCRIPTING,
@@ -430,7 +480,12 @@ class ReclaimContentScript {
       case MESSAGE_ACTIONS.PROVIDER_DATA_READY:
         // Only process provider data if this is a managed tab
         if (!this.isManagedTab) {
-          logger.info("[Content] Tab is not managed by extension", "content.tab");
+          // Not an exception: PROVIDER_DATA_READY is broadcast, so the content
+          // script in the *originating* tab correctly declines it. Tagging this
+          // TAB_NOT_MANAGED_BY_EXTENSION_EXCEPTION put an exception event in
+          // every healthy session. The event stays on the real failure, where
+          // messageRouter rejects a request from an unmanaged tab.
+          logger.debug("[Content] Ignoring provider data: tab is not managed", "content.tab");
           sendResponse({ success: false, message: "Tab is not managed by extension" });
           break;
         }
@@ -494,7 +549,9 @@ class ReclaimContentScript {
           (response) => {
             if (!response.success || !response.isManaged) {
               // This tab is not managed by the extension, don't show popup
-              logger.info("[Content] Tab is not managed by extension", "content.tab");
+              // Same as above: declining to draw the popup in an unmanaged
+              // tab is the normal outcome, not an exception.
+              logger.debug("[Content] Not showing popup: tab is not managed", "content.tab");
               sendResponse({ success: false, message: "Tab is not managed by extension" });
               return;
             }
@@ -562,7 +619,7 @@ class ReclaimContentScript {
       // Handle status update messages from background script
       case MESSAGE_ACTIONS.CLAIM_CREATION_REQUESTED:
         if (this.verificationPopup) {
-          this.verificationPopup.handleClaimCreationRequested(data.requestHash);
+          this.verificationPopup.handleClaimCreationRequested(data.requestHash, data.progress);
         }
         logger.info("[Content] Claim creation requested", "content.claim");
         sendResponse({ success: true });
@@ -594,7 +651,7 @@ class ReclaimContentScript {
 
       case MESSAGE_ACTIONS.PROOF_GENERATION_SUCCESS:
         if (this.verificationPopup) {
-          this.verificationPopup.handleProofGenerationSuccess(data.requestHash);
+          this.verificationPopup.handleProofGenerationSuccess(data.requestHash, data.progress);
         }
         logger.info("[Content] Proof generation success", "content.proof");
         sendResponse({ success: true });
@@ -691,6 +748,29 @@ class ReclaimContentScript {
     if (event.source !== window) return;
     const { action, data, messageId, extensionID } = event.data;
 
+    // MAIN-world log relay. The interceptor and injection scripts have no
+    // chrome.runtime, so this is the only route their diagnostics have to the
+    // hub. Relayed with the originating context, not "content", so the log
+    // still says where interception actually failed.
+    //
+    // Deliberately not gated on extensionID: the bridge is a same-window
+    // postMessage from our own injected script and carries no privileges. It
+    // is gated on managed-tab status in the background's message router like
+    // every other content-script message.
+    if (action === RECLAIM_SDK_ACTIONS.LOG && data?.message) {
+      logger.relay(data.message, data.type, data.level, data.context || "page", data.options);
+      // Both this script and the page-world scripts start at document_start, so
+      // the first config push can land before the bridge installed its
+      // listener. The bridge's defaults are permissive, so nothing is lost —
+      // but a consumer who disabled the console would still see page-world
+      // logs. Re-send once, now that we know the bridge is listening.
+      if (!this._logConfigEchoed && this._lastLogConfig) {
+        this._logConfigEchoed = true;
+        this.pushLogConfigToPage(this._lastLogConfig);
+      }
+      return;
+    }
+
     // Check if the message is meant for this extension
     if (action === RECLAIM_SDK_ACTIONS.CHECK_EXTENSION) {
       // Send response back to the page
@@ -708,7 +788,6 @@ class ReclaimContentScript {
       );
     }
 
-    // Handle provider ID request from injection script
     if (action === "RECLAIM_GET_PROVIDER_ID" && event.data.source === "injection-script") {
       // Respond with the provider ID from extension context
       window.postMessage(
@@ -739,7 +818,9 @@ class ReclaimContentScript {
       if (!this.checkExtensionId(extensionID)) {
         return;
       }
-      logger.info("[Content] Starting verification with data from SDK", "content.verification");
+      logger.info("[Content] Starting verification with data from SDK", "content.verification", {
+        eventType: EVENT_TYPES.WEB_PAGE_READY,
+      });
 
       chrome.runtime.sendMessage(
         {
@@ -888,7 +969,9 @@ class ReclaimContentScript {
           );
         },
       );
-      logger.info("[Content] Parameters get", "content.data");
+      // FINE: the background logs the same event, and a provider script can
+      // call getParametersSync() on every render.
+      logger.debug("[Content] Parameters get", "content.data");
       return;
     }
 
@@ -1027,7 +1110,6 @@ class ReclaimContentScript {
     }
   }
 
-  // Clean up old intercepted data
   cleanupInterceptedData() {
     const now = Date.now();
     const timeout = INTERCEPTED_DATA_MAX_AGE_MS;
@@ -1040,7 +1122,6 @@ class ReclaimContentScript {
     }
   }
 
-  // Start filtering intercepted network requests
   startNetworkFiltering() {
     if (!this.providerData) {
       return;
@@ -1053,6 +1134,8 @@ class ReclaimContentScript {
     this.isFiltering = true;
     this.filteringStartTime = Date.now();
     this.stopStoringInterceptions = false;
+    this.matchProgress.clear();
+    this.startNoMatchTimer();
 
     // Run filtering immediately
     this.filterInterceptedRequests();
@@ -1062,7 +1145,6 @@ class ReclaimContentScript {
       clearInterval(this.filteringInterval);
     }
 
-    // Then set up interval for continuous filtering
     this.filteringInterval = setInterval(() => {
       // Skip if we've already found all requests
       if (this.stopStoringInterceptions) {
@@ -1079,13 +1161,18 @@ class ReclaimContentScript {
     }, NETWORK_FILTERING_INTERVAL_MS);
   }
 
-  // Stop network filtering
   stopNetworkFiltering() {
-    // Clear the filtering interval
     if (this.filteringInterval) {
       clearInterval(this.filteringInterval);
       this.filteringInterval = null;
     }
+
+    // Report before disarming: reaching NETWORK_FILTERING_TIMEOUT_MS with
+    // nothing matched is exactly the case the summary exists for.
+    if (this.filteredRequests.length === 0 && this.noMatchTimer) {
+      this.reportNoMatchSummary();
+    }
+    this.clearNoMatchTimer();
 
     // Stop filtering flag
     this.isFiltering = false;
@@ -1100,13 +1187,11 @@ class ReclaimContentScript {
     }
   }
 
-  // Filter intercepted requests with provider criteria
   filterInterceptedRequests() {
     if (!this.providerData || !this.providerData.requestData) {
       return;
     }
 
-    // For each linked request/response pair
     for (const [key, combinedData] of this.interceptedRequestResponses.entries()) {
       // Skip already filtered requests
       if (this.filteredRequests.includes(key)) {
@@ -1127,9 +1212,21 @@ class ReclaimContentScript {
       };
 
       // Check against each criteria in provider data
-      for (const criteria of this.providerData.requestData) {
-        if (filterRequest(formattedRequest, criteria, this.parameters, logger)) {
+      for (
+        let matcherIndex = 0;
+        matcherIndex < this.providerData.requestData.length;
+        matcherIndex++
+      ) {
+        const criteria = this.providerData.requestData[matcherIndex];
+        const verdict = describeRequestMatch(formattedRequest, criteria, this.parameters, logger);
+        this.reportMatchAttempt(matcherIndex, key, formattedRequest, criteria, verdict);
+
+        if (verdict.matched) {
           // Mark this request as filtered
+          // Deliberately no eventType: the background's "Filtering request for
+          // request hash" line already carries REQUEST_MATCHED, and it is the
+          // authoritative one (it has the requestHash). Tagging this line too
+          // double-counted the event — a 3-claim session reported 6.
           logger.info(
             "[Content] Matching request found: " +
               formattedRequest.method +
@@ -1138,6 +1235,7 @@ class ReclaimContentScript {
             "content.filter",
           );
 
+          this.clearNoMatchTimer();
           this.filteredRequests.push(key);
 
           // Send to background script for cookie fetching and claim creation
@@ -1145,18 +1243,17 @@ class ReclaimContentScript {
             formattedRequest,
             criteria,
             this.providerData.loginUrl,
+            key,
           );
         }
       }
     }
 
-    // If we've found all possible matching requests, stop filtering
     if (this.filteredRequests.length >= this.providerData.requestData.length) {
       // Stop filtering and prevent further storage
       this.stopStoringInterceptions = true;
       this.isFiltering = false;
 
-      // Clear filtering interval
       if (this.filteringInterval) {
         clearInterval(this.filteringInterval);
         this.filteringInterval = null;
@@ -1168,13 +1265,127 @@ class ReclaimContentScript {
         this.cleanupInterval = null;
       }
 
-      // Clear all stored requests and responses
       this.interceptedRequestResponses.clear();
     }
   }
 
-  // Send filtered request to background script
-  sendFilteredRequestToBackground(formattedRequest, matchingCriteria, loginUrl) {
+  /**
+   * Record how far one request got against one matcher, and log it the first
+   * time it gets that far.
+   *
+   * Only *near misses* are logged individually. A plain url rejection is the
+   * overwhelming majority — 32 of 33 requests in a typical page load — and says
+   * nothing beyond "this wasn't the request", which the REQUEST_INTERCEPTED
+   * line already covers. Anything past the url check means the provider very
+   * nearly matched, which is the case worth a line: a stale bodySniff template
+   * or a responseMatch that no longer holds is otherwise completely silent, and
+   * the session dies on the timer looking like the user never logged in.
+   *
+   * Every url rejection is still counted, and surfaces in the timeout summary.
+   */
+  reportMatchAttempt(matcherIndex, requestKey, request, criteria, verdict) {
+    const progressKey = `${matcherIndex}|${requestKey}`;
+    const reached = MATCH_STAGE_ORDER.indexOf(verdict.stage);
+    const furthest = this.matchProgress.get(progressKey);
+
+    // A request is re-evaluated every tick, and can legitimately advance when
+    // its response finally arrives. Report advances only.
+    if (furthest !== undefined && reached <= furthest) return;
+    this.matchProgress.set(progressKey, reached);
+
+    if (verdict.matched || verdict.stage === MATCH_STAGES.URL) return;
+
+    // `responseMissing` is the normal state on the tick between a request and
+    // its response, so it is not worth an INFO line on its own.
+    const level = verdict.stage === MATCH_STAGES.RESPONSE_MISSING ? "debug" : "info";
+
+    logger[level](
+      `[Content] Matcher #${matcherIndex} ▸ ${verdict.stage} did NOT match: ${verdict.detail} — ${request.method} ${request.url}`,
+      "content.filter",
+      {
+        // The provider-authored templates that decided it. These are config,
+        // not user data — but they go through the payload rather than the
+        // message so they are capped and redaction still sees them.
+        payload: {
+          urlTemplate: criteria?.url,
+          bodyTemplate: criteria?.bodySniff?.enabled ? criteria?.bodySniff?.template : undefined,
+        },
+      },
+    );
+  }
+
+  /**
+   * Arm the "nothing ever matched" timer.
+   *
+   * The background's SessionTimerManager only starts on the *first* intercepted
+   * request, so it cannot distinguish "no traffic at all" from "plenty of
+   * traffic, none of it matching" — which is why
+   * RECLAIM_VERIFICATION_NO_ACTIVITY_DETECTED_EXCEPTION had no trigger. This
+   * timer runs in the content script, where the counters live, and reports
+   * whichever of the two actually happened.
+   */
+  startNoMatchTimer() {
+    this.clearNoMatchTimer();
+    this.noMatchTimer = setTimeout(() => {
+      this.noMatchTimer = null;
+      if (this.filteredRequests.length > 0) return;
+      this.reportNoMatchSummary();
+    }, SESSION_TIMER_DURATION_MS);
+  }
+
+  clearNoMatchTimer() {
+    if (this.noMatchTimer) {
+      clearTimeout(this.noMatchTimer);
+      this.noMatchTimer = null;
+    }
+  }
+
+  /** One line per matcher saying how far the closest request got. */
+  reportNoMatchSummary() {
+    const matchers = this.providerData?.requestData || [];
+    const seconds = Math.round(SESSION_TIMER_DURATION_MS / 1000);
+
+    // Tally the furthest stage each request reached, per matcher.
+    const tallies = matchers.map(() => ({ seen: 0, past: MATCH_STAGE_ORDER.map(() => 0) }));
+    for (const [progressKey, reached] of this.matchProgress.entries()) {
+      const matcherIndex = Number(progressKey.split("|")[0]);
+      const tally = tallies[matcherIndex];
+      if (!tally) continue;
+      tally.seen++;
+      for (let stage = 0; stage <= reached; stage++) tally.past[stage]++;
+    }
+
+    const nothingSeen = tallies.every((tally) => tally.seen === 0);
+
+    for (let i = 0; i < matchers.length; i++) {
+      const tally = tallies[i] || { seen: 0, past: MATCH_STAGE_ORDER.map(() => 0) };
+      const stageIndex = (stage) => MATCH_STAGE_ORDER.indexOf(stage);
+      logger.info(
+        `[Content] No request matched in ${seconds}s. Matcher #${i} (${matchers[i]?.method} ${matchers[i]?.url}): ` +
+          // Reaching stage N means every check before N passed, so each count
+          // is "url matched", "url+method matched", "url+method+body matched".
+          `${tally.seen} seen, ${tally.past[stageIndex(MATCH_STAGES.METHOD)]} url-matched, ` +
+          `${tally.past[stageIndex(MATCH_STAGES.BODY)]} method-matched, ` +
+          `${tally.past[stageIndex(MATCH_STAGES.RESPONSE_MISSING)]} body-matched, ` +
+          `${tally.past[stageIndex(MATCH_STAGES.MATCHED)]} fully matched`,
+        "content.filter",
+        {
+          // NO_ACTIVITY is truthful only when nothing was intercepted at all —
+          // this timer is what finally gives that upstream name a trigger. With
+          // traffic seen the session did have activity, it just never produced
+          // a claim, which is what the background's session timer already calls
+          // CLAIM_CREATION_TIMED_OUT_EXCEPTION. Deliberately not
+          // FILTER_REQUEST_ERROR: that marks a *thrown* filtering error, and
+          // mixing a clean non-match into it would break that query.
+          eventType: nothingSeen
+            ? EVENT_TYPES.RECLAIM_VERIFICATION_NO_ACTIVITY_DETECTED_EXCEPTION
+            : EVENT_TYPES.CLAIM_CREATION_TIMED_OUT_EXCEPTION,
+        },
+      );
+    }
+  }
+
+  sendFilteredRequestToBackground(formattedRequest, matchingCriteria, loginUrl, requestKey) {
     logger.info(
       "[Content] Sending filtered request to background: " + formattedRequest.url,
       "content.filter",
@@ -1193,12 +1404,26 @@ class ReclaimContentScript {
         },
       },
       (response) => {
-        // Background response handled silently
+        // Background now owns authoritative xPath/jsonPath resolution, so it can
+        // legitimately say "this response doesn't carry the data yet". Release
+        // the key so a later response for the same request is filtered again;
+        // without this the request stays marked as found and the flow stalls
+        // until the session timer fires.
+        if (response?.retryable && requestKey !== undefined) {
+          const idx = this.filteredRequests.indexOf(requestKey);
+          if (idx !== -1) {
+            this.filteredRequests.splice(idx, 1);
+          }
+          logger.info(
+            "[Content] Background could not resolve redactions yet, will keep filtering: " +
+              formattedRequest.url,
+            "content.filter",
+          );
+        }
       },
     );
   }
 
-  // Helper method to store provider ID in website's localStorage
   setProviderIdInLocalStorage(providerId) {
     // Don't store null, undefined, or 'unknown' values
     const key = "reclaimBrowserExtensionProviderId";
@@ -1238,8 +1463,11 @@ class ReclaimContentScript {
 
     if (!injectionScript?.length) {
       localStorage.removeItem(key);
-      logger.error(
-        "[Content] Skipping localStorage storage for injection script",
+      // Most providers carry no customInjection at all, so this is the normal
+      // path, not a failure. At ERROR it put an error line in every session for
+      // every such provider, which trains you to ignore the level.
+      logger.debug(
+        "[Content] No injection script for this provider; nothing to store",
         "content.storage",
       );
 
@@ -1285,6 +1513,5 @@ class ReclaimContentScript {
   }
 }
 
-// Initialize content script
 const contentScript = new ReclaimContentScript();
 export default contentScript;

--- a/src/interceptor/injection-scripts.js
+++ b/src/interceptor/injection-scripts.js
@@ -1,3 +1,9 @@
+import { createPageLogger } from "./log-bridge";
+
+// The window.Reclaim surface is installed at module scope, before the IIFE
+// below builds its own logger, so it needs one of its own.
+const apiLogger = createPageLogger("injection", "injection.api");
+
 window.Reclaim = window.Reclaim || {};
 let __reclaimParams = {};
 
@@ -32,7 +38,7 @@ window.Reclaim.updatePublicData = function (obj) {
       "*",
     );
   } catch (e) {
-    console.error("Reclaim.updatePublicData error:", e);
+    apiLogger.error("Reclaim.updatePublicData error:", e);
   }
 };
 
@@ -55,16 +61,21 @@ window.Reclaim.reportProviderError = function (msg) {
       "*",
     );
   } catch (e) {
-    console.error("Reclaim.reportProviderError error:", e);
+    apiLogger.error("Reclaim.reportProviderError error:", e);
   }
 };
 
 window.Reclaim.requestClaim = function (rdObject) {
   try {
-    console.log("Reclaim.requestClaim rdObject", rdObject);
+    // Was a bare console.log of the whole rdObject. That is a provider-authored
+    // request descriptor which routinely carries the response the claim is
+    // being built from, printed into the *provider tab's* console — the one
+    // place the user can read it — with no config gate and no route to the
+    // endpoint. Through the bridge it obeys logLevel and gets redacted at INFO.
+    apiLogger.info("Reclaim.requestClaim", { rdObject });
     window.postMessage({ action: "RECLAIM_REQUEST_CLAIM", data: { rdObject } }, "*");
   } catch (e) {
-    console.error("Reclaim.requestClaim error:", e);
+    apiLogger.error("Reclaim.requestClaim error:", e);
   }
 };
 
@@ -108,15 +119,10 @@ try {
   const PROVIDER_API_ENDPOINT = (providerId) =>
     `${BACKEND_URL}/api/providers/${providerId}/custom-injection`;
 
-  // Debug utility for logging
-  const debug = {
-    log: (...args) => console.log("🔍 [Injection Script]:", ...args),
-    error: (...args) => console.error("❌ [Injection Script Error]:", ...args),
-    info: (...args) => console.info("ℹ️ [Injection Script Info]:", ...args),
-    // log: (...args) => undefined,
-    // error: (...args) => undefined,
-    // info: (...args) => undefined
-  };
+  // Logging for the injection script. Routed through the page-world bridge so
+  // provider-script failures land in the session's diagnostic dump instead of
+  // only in the page console, where nobody sees them after the fact.
+  const debug = createPageLogger("injection", "injection.script");
 
   /**
    * IMPORTANT: localStorage Context Isolation
@@ -210,7 +216,6 @@ try {
 
       const scriptContent = await response.text();
 
-      // Check if we got a valid script
       if (!scriptContent || scriptContent.trim() === "") {
         debug.info(`No injection script content found for provider: ${providerId}`);
         return null;
@@ -367,7 +372,6 @@ try {
         return;
       }
 
-      // Fetch the injection script from localStorage
       const injectionScript = localStorage.getItem(
         `reclaimBrowserExtensionInjectionScript:${providerId}`,
       );

--- a/src/interceptor/log-bridge.js
+++ b/src/interceptor/log-bridge.js
@@ -128,11 +128,16 @@ export function createPageLogger(context, category) {
     if (shouldConsole(level)) {
       const fn =
         level === "SEVERE" ? console.error : level === "WARNING" ? console.warn : console.log;
-      const prefix = `[${level}] [${context}] ${message}`;
+      // The format string is a literal and `message` is an ARGUMENT, never
+      // interpolated into it. `message` is built from page-world content, and
+      // the console parses %s/%c/%o in its first argument: a message
+      // containing "%s" swallowed the payload and spliced it into the middle
+      // of the text, and "%c" let a page inject CSS into its own console.
+      // Substituted arguments are not re-parsed, so this closes both.
       if (payload !== undefined) {
-        fn(prefix, payload);
+        fn("[%s] [%s] %s", level, context, message, payload);
       } else {
-        fn(prefix);
+        fn("[%s] [%s] %s", level, context, message);
       }
     }
 

--- a/src/interceptor/log-bridge.js
+++ b/src/interceptor/log-bridge.js
@@ -1,0 +1,171 @@
+/**
+ * Log bridge for MAIN-world scripts.
+ *
+ * The network interceptor and the injection scripts run in the page's own
+ * JavaScript world. There is no `chrome.runtime` there, so until this bridge
+ * existed their diagnostics went to `console` and nowhere else: never to the
+ * endpoint, and never gated by the SDK's log config. That is the most
+ * failure-prone stage of the whole flow — request interception — logging into a
+ * void.
+ *
+ * The bridge posts each line to the content script (`RECLAIM_LOG`), which
+ * relays it to the LoggingHub like any other context. Console mirroring is
+ * gated by a config the content script pushes down with `RECLAIM_LOG_CONFIG`,
+ * since the page world cannot read `chrome.storage` itself.
+ *
+ * Defaults are permissive on purpose: a log emitted before the first config
+ * push should still be visible, and `document_start` injection means the very
+ * first lines arrive before anything else is ready.
+ */
+
+const LOG_ACTION = "RECLAIM_LOG";
+const LOG_CONFIG_ACTION = "RECLAIM_LOG_CONFIG";
+
+// Mirrors LOG_LEVEL / the alias table in src/utils/logger/constants.js. Kept as
+// a literal for the same dependency-free reason as `config` below; the old
+// ERROR/WARN/DEBUG spellings are ranked too so a stale config push (or an older
+// content script) still resolves to something sensible.
+const LEVEL_RANK = {
+  SEVERE: 1,
+  ERROR: 1,
+  WARNING: 2,
+  WARN: 2,
+  INFO: 3,
+  CONFIG: 3,
+  FINE: 4,
+  DEBUG: 4,
+};
+
+// Must match DEFAULT_LOG_CONFIG in src/utils/logger/constants.js. Not imported
+// from there on purpose: these scripts are injected into the page's own world
+// at document_start and stay dependency-free. Defaulting the console OFF is the
+// safe direction — this runs inside the provider's page, so being wrong the
+// other way narrates the verification in the end user's devtools until the
+// content script's config push lands. Forwarding to the hub is unconditional
+// either way, so nothing is lost from the diagnostic dump.
+let config = { consoleEnabled: false, logLevel: "INFO" };
+let listening = false;
+
+/**
+ * Listen for config pushed down by the content script. Installed once, lazily,
+ * so importing this module has no side effect until a logger is created.
+ */
+function ensureConfigListener() {
+  if (listening || typeof window === "undefined") return;
+  listening = true;
+  try {
+    window.addEventListener("message", (event) => {
+      if (event.source !== window) return;
+      const data = event.data;
+      if (data?.action === LOG_CONFIG_ACTION && data.data?.config) {
+        config = { ...config, ...data.data.config };
+      }
+    });
+  } catch {
+    // A hostile page may have tampered with addEventListener; keep defaults.
+  }
+}
+
+function shouldConsole(level) {
+  if (!config.consoleEnabled) return false;
+  const threshold = LEVEL_RANK[config.logLevel] || LEVEL_RANK.INFO;
+  return (LEVEL_RANK[level] || LEVEL_RANK.INFO) <= threshold;
+}
+
+/**
+ * Split console-style args into a message string and a structured payload.
+ *
+ * Strings and Errors go into the message: they are safe to store verbatim and
+ * an Error reads better as `TypeError: bad input` than as `{}` (Error fields
+ * are non-enumerable, so JSON.stringify yields nothing useful).
+ *
+ * Anything else — a plain object, an array — becomes `payload` and is sent as a
+ * live object rather than stringified here. That matters: the hub redacts the
+ * payload on the way to the endpoint while both consoles show real values. If
+ * this function stringified objects into the message instead, a caller logging
+ * a response body would push it straight past redaction to Loki.
+ *
+ * @returns {{message: string, payload: *}}
+ */
+function split(args) {
+  const words = [];
+  const objects = [];
+
+  for (const arg of args) {
+    if (typeof arg === "string") {
+      words.push(arg);
+    } else if (arg instanceof Error) {
+      words.push(`${arg.name}: ${arg.message}`);
+    } else if (arg !== null && typeof arg === "object") {
+      objects.push(arg);
+    } else {
+      words.push(String(arg));
+    }
+  }
+
+  return {
+    message: words.join(" "),
+    payload: objects.length === 0 ? undefined : objects.length === 1 ? objects[0] : objects,
+  };
+}
+
+/**
+ * Create a logger for a MAIN-world script.
+ *
+ * The returned object keeps the `log`/`info`/`error` shape the interceptor
+ * already used, so call sites did not have to change, and adds `warn`/`debug`.
+ *
+ * @param {string} context - "interceptor" | "injection"
+ * @param {string} category - dotted log category, e.g. "interceptor.network"
+ * @returns {{log: Function, info: Function, warn: Function, error: Function, debug: Function}}
+ */
+export function createPageLogger(context, category) {
+  ensureConfigListener();
+
+  const emit = (level, args, eventType) => {
+    const { message, payload } = split(args);
+
+    if (shouldConsole(level)) {
+      const fn =
+        level === "SEVERE" ? console.error : level === "WARNING" ? console.warn : console.log;
+      const prefix = `[${level}] [${context}] ${message}`;
+      if (payload !== undefined) {
+        fn(prefix, payload);
+      } else {
+        fn(prefix);
+      }
+    }
+
+    const post = (data) => window.postMessage({ action: LOG_ACTION, data }, "*");
+
+    try {
+      post({ message, type: category, level, context, options: { eventType, payload } });
+    } catch {
+      // postMessage structured-clones, so a payload holding a function, a DOM
+      // node or a cycle throws. Retry without it: losing the detail beats
+      // losing the log line that says something went wrong.
+      try {
+        post({ message, type: category, level, context, options: { eventType } });
+      } catch {
+        // Nothing left to try.
+      }
+    }
+  };
+
+  return {
+    log: (...args) => emit("FINE", args),
+    debug: (...args) => emit("FINE", args),
+    fine: (...args) => emit("FINE", args),
+    info: (...args) => emit("INFO", args),
+    warn: (...args) => emit("WARNING", args),
+    error: (...args) => emit("SEVERE", args),
+    /**
+     * Log a named lifecycle event (a value from EVENT_TYPES). Kept separate
+     * from the level methods so the variadic console-style signature above
+     * stays unchanged for the interceptor's existing call sites.
+     */
+    event: (eventType, ...args) => emit("INFO", args, eventType),
+  };
+}
+
+export { LOG_ACTION, LOG_CONFIG_ACTION };

--- a/src/interceptor/log-bridge.test.js
+++ b/src/interceptor/log-bridge.test.js
@@ -1,0 +1,142 @@
+/**
+ * The bridge is the only route MAIN-world diagnostics have to the endpoint:
+ * the interceptor and injection scripts run in the page's world, where there is
+ * no `chrome.runtime`. Before it existed, every line from the interception
+ * layer — the most failure-prone stage of the flow — went to the page console
+ * and nowhere else.
+ *
+ * These tests use a fake `window`, since the module only needs `postMessage`
+ * and `addEventListener`.
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+
+const posted = [];
+let messageListener = null;
+
+globalThis.window = {
+  postMessage: (message) => posted.push(message),
+  addEventListener: (event, handler) => {
+    if (event === "message") messageListener = handler;
+  },
+};
+
+const { createPageLogger, LOG_ACTION, LOG_CONFIG_ACTION } = await import("./log-bridge.js");
+
+// The config listener installs lazily on the first createPageLogger call — the
+// module has no import-time side effects on purpose, since it is bundled into
+// scripts injected at document_start. So one logger has to exist before any
+// config can be pushed.
+createPageLogger("bootstrap", "bootstrap");
+
+/** Simulate the content script pushing log config into the page. */
+function pushConfig(config) {
+  messageListener({
+    source: globalThis.window,
+    data: { action: LOG_CONFIG_ACTION, data: { config } },
+  });
+}
+
+beforeEach(() => {
+  posted.length = 0;
+  pushConfig({ consoleEnabled: false, logLevel: "DEBUG" });
+});
+
+describe("createPageLogger", () => {
+  it("posts every level to the content script for relay", () => {
+    const logger = createPageLogger("interceptor", "interceptor.network");
+    logger.info("intercepted a request");
+    logger.warn("slow response");
+    logger.error("interception failed");
+    logger.debug("verbose detail");
+
+    assert.equal(posted.length, 4);
+    // Platform spellings, so a page-world line filters alongside every other
+    // SDK's in the log viewer.
+    assert.deepEqual(
+      posted.map((m) => m.data.level),
+      ["INFO", "WARNING", "SEVERE", "FINE"],
+    );
+    for (const message of posted) {
+      assert.equal(message.action, LOG_ACTION);
+      assert.equal(message.data.context, "interceptor");
+      assert.equal(message.data.type, "interceptor.network");
+    }
+  });
+
+  it("keeps the log/info/error shape the interceptor already called", () => {
+    const logger = createPageLogger("injection", "injection.script");
+    for (const method of ["log", "info", "warn", "error", "debug"]) {
+      assert.equal(typeof logger[method], "function", `missing ${method}`);
+    }
+    // The old local `debug` object treated .log as verbose output.
+    logger.log("legacy call site");
+    assert.equal(posted[0].data.level, "FINE");
+  });
+
+  it("forwards regardless of the console setting", () => {
+    // Console config controls local mirroring only. Silencing the page console
+    // must not silence the diagnostic dump.
+    pushConfig({ consoleEnabled: false, logLevel: "ERROR" });
+    const logger = createPageLogger("interceptor", "interceptor.network");
+    logger.debug("still needs to reach the endpoint");
+    assert.equal(posted.length, 1);
+  });
+
+  it("sends objects as a structured payload, not stringified into the message", () => {
+    // Stringifying here would push the value past the hub's redaction straight
+    // to the endpoint. The object has to travel as an object.
+    const logger = createPageLogger("interceptor", "interceptor.network");
+    logger.info("request", { url: "https://x/y", method: "GET" });
+
+    assert.equal(posted[0].data.message, "request");
+    assert.deepEqual(posted[0].data.options.payload, { url: "https://x/y", method: "GET" });
+  });
+
+  it("renders Errors into the message, since their fields do not serialize", () => {
+    const logger = createPageLogger("interceptor", "interceptor.network");
+    logger.error("boom", new TypeError("bad input"));
+    assert.equal(posted[0].data.message, "boom TypeError: bad input");
+    assert.equal(posted[0].data.options.payload, undefined);
+  });
+
+  it("collects multiple objects into one payload", () => {
+    const logger = createPageLogger("interceptor", "interceptor.network");
+    logger.info("pair", { a: 1 }, { b: 2 });
+    assert.equal(posted[0].data.message, "pair");
+    assert.deepEqual(posted[0].data.options.payload, [{ a: 1 }, { b: 2 }]);
+  });
+
+  it("keeps the log line when the payload cannot be cloned", () => {
+    // postMessage structured-clones, so a cycle throws. The line saying
+    // something went wrong matters more than the detail.
+    const realPostMessage = globalThis.window.postMessage;
+    globalThis.window.postMessage = (message) => {
+      if (message.data.options?.payload !== undefined)
+        throw new DOMException("could not be cloned");
+      posted.push(message);
+    };
+    try {
+      const logger = createPageLogger("interceptor", "interceptor.network");
+      const cyclic = {};
+      cyclic.self = cyclic;
+      assert.doesNotThrow(() => logger.info("cyclic", cyclic));
+      assert.equal(posted.length, 1);
+      assert.equal(posted[0].data.message, "cyclic");
+      assert.equal(posted[0].data.options.payload, undefined);
+    } finally {
+      globalThis.window.postMessage = realPostMessage;
+    }
+  });
+
+  it("ignores config messages that did not come from this window", () => {
+    messageListener({
+      source: { not: "our window" },
+      data: { action: LOG_CONFIG_ACTION, data: { config: { consoleEnabled: true } } },
+    });
+    // Nothing to assert on the console directly; the point is that a foreign
+    // frame cannot flip our logging on. No throw, and no posted messages.
+    assert.equal(posted.length, 0);
+  });
+});

--- a/src/interceptor/network-interceptor.js
+++ b/src/interceptor/network-interceptor.js
@@ -1,19 +1,21 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
 
+import { createPageLogger } from "./log-bridge";
+// Plain constants file, no imports of its own, so this stays cheap for a
+// bundle injected at document_start.
+import { EVENT_TYPES } from "../utils/logger/constants";
+
 (function () {
   const injectionFunction = function () {
     /**
-     * Debug utility for consistent logging across the interceptor
-     * @type {Object}
+     * Logging for the interceptor.
+     *
+     * Goes through the page-world bridge rather than straight to `console`, so
+     * these lines reach the LoggingHub and the diagnostic endpoint like every
+     * other context's, and respect the SDK's console config. The `log`/`info`/
+     * `error` shape is unchanged from the previous local `debug` object.
      */
-    const debug = {
-      log: (...args) => console.log("🔍 [Debug]:", ...args),
-      error: (...args) => console.error("❌ [Error]:", ...args),
-      info: (...args) => console.info("ℹ️ [Info]:", ...args),
-      // log: (...args) => undefined, // Disabled console.log("🔍 [Debug]:", ...args),
-      // error: (...args) => undefined, // Disabled console.error("❌ [Error]:", ...args),
-      // info: (...args) => undefined, // Disabled console.info("ℹ️ [Info]:", ...args),
-    };
+    const debug = createPageLogger("interceptor", "interceptor.network");
 
     /**
      * RequestInterceptor class
@@ -49,7 +51,6 @@
        */
       async processRequestMiddlewares(requestData) {
         try {
-          // Run all request middlewares in parallel
           await Promise.all(this.requestMiddlewares.map((middleware) => middleware(requestData)));
         } catch (error) {
           debug.error("Error in request middleware:", error);
@@ -113,7 +114,6 @@
         const originalFetch = this.originalFetch;
         const self = this;
 
-        // Create a proxy for the fetch function
         window.fetch = new Proxy(originalFetch, {
           apply: async function (target, thisArg, argumentsList) {
             const [url, options = {}] = argumentsList;
@@ -131,7 +131,6 @@
               },
             };
 
-            // Add a marker property to the request
             Object.defineProperty(requestData, "_rc", {
               value: true,
               enumerable: false,
@@ -170,7 +169,6 @@
             // Start parsing ASAP; don't clone forAudit again
             self.processResponseMiddlewares(forAudit, requestData).catch(debug.error);
 
-            // Return the app's branch
             return forApp;
 
             // FIX: Don't create a prototype-chained response, use the original
@@ -206,7 +204,6 @@
         // Create a WeakMap to store request info for each XHR instance
         const requestInfoMap = new WeakMap();
 
-        // Modify open method on prototype
         XMLHttpRequest.prototype.open = function (...args) {
           // Mark this instance as intercepted
           Object.defineProperty(this, "_rc", {
@@ -226,7 +223,6 @@
             },
           };
 
-          // Store request info in WeakMap
           requestInfoMap.set(this, requestInfo);
 
           // Call original method
@@ -252,13 +248,11 @@
           return originalSetRequestHeader.apply(this, arguments);
         };
 
-        // Modify send method on prototype
         XMLHttpRequest.prototype.send = function (data) {
           const requestInfo = requestInfoMap.get(this);
           if (requestInfo) {
             requestInfo.options.body = data;
 
-            // Process request middlewares
             const runRequestMiddlewares = async () => {
               try {
                 await Promise.all(
@@ -269,7 +263,6 @@
               }
             };
 
-            // Store original onreadystatechange
             const originalHandler = this.onreadystatechange;
 
             // Override onreadystatechange
@@ -347,7 +340,6 @@
                       writable: false,
                     });
 
-                    // Process response middlewares
                     await self.processResponseMiddlewares(responseObj, requestInfo);
                   } catch (error) {
                     debug.error("Error processing XHR response:", error);
@@ -356,7 +348,6 @@
               }
             };
 
-            // Run middlewares then send
             runRequestMiddlewares().then(() => {
               originalSend.call(this, requestInfo.options.body);
             });
@@ -514,6 +505,15 @@
             data: combinedData,
           },
           "*",
+        );
+
+        // Named lifecycle event. Method and URL only — the response body here
+        // would be the user's data, and the interception itself is what matters.
+        debug.event(
+          EVENT_TYPES.REQUEST_INTERCEPTED,
+          "Intercepted",
+          combinedData.request.method,
+          url,
         );
       } catch (error) {
         debug.error("Error processing request/response:", error);

--- a/src/offscreen/offscreen.js
+++ b/src/offscreen/offscreen.js
@@ -2,10 +2,10 @@
 import "../utils/polyfills";
 import { MESSAGE_ACTIONS, MESSAGE_SOURCES, RECLAIM_SESSION_STATUS } from "../utils/constants";
 import { createClaimOnAttestor } from "@reclaimprotocol/attestor-core/browser";
-// Import our specialized WebSocket implementation for offscreen document
 import { WebSocket } from "../utils/offscreen-websocket";
 import { updateSessionStatus } from "../utils/fetch-calls";
 import { createRemoteLogger } from "../utils/logger/RemoteLogger";
+import { EVENT_TYPES } from "../utils/logger/constants";
 import { PROOF_GENERATION_TIMEOUT_MS } from "../utils/constants/config";
 
 const logger = createRemoteLogger("offscreen");
@@ -15,6 +15,7 @@ if (typeof WebAssembly === "undefined") {
   logger.error(
     "[OFFSCREEN] WebAssembly is not available in this browser context",
     "offscreen.init",
+    { eventType: EVENT_TYPES.OFFSCREEN_DOCUMENT_NOT_READY_EXCEPTION },
   );
 }
 
@@ -43,7 +44,9 @@ class OffscreenProofGenerator {
   }
 
   init() {
-    logger.info("[OFFSCREEN] Offscreen ready", "offscreen.init");
+    logger.info("[OFFSCREEN] Offscreen ready", "offscreen.init", {
+      eventType: EVENT_TYPES.OFFSCREEN_DOCUMENT_READY,
+    });
     chrome.runtime.onMessage.addListener(this.handleMessage.bind(this));
     this.sendReadySignal();
   }
@@ -70,7 +73,13 @@ class OffscreenProofGenerator {
       case MESSAGE_ACTIONS.GENERATE_PROOF:
         (async () => {
           try {
-            logger.info("[OFFSCREEN] Generating proof", "offscreen.proof");
+            logger.info("[OFFSCREEN] Generating proof", "offscreen.proof", {
+              eventType: EVENT_TYPES.PROOF_GENERATION_STARTED,
+            });
+
+            // Captured up front: generateProof() deletes sessionId off the
+            // claim data before handing it to the attestor.
+            const sessionId = data?.sessionId;
 
             const proof = await this.generateProof(data);
 
@@ -82,6 +91,7 @@ class OffscreenProofGenerator {
               logger.error(
                 "[OFFSCREEN] Proof contains embedded error: " + embeddedErr,
                 "offscreen.proof",
+                { eventType: EVENT_TYPES.PROOF_GENERATION_FAILED_EXCEPTION },
               );
               chrome.runtime.sendMessage({
                 action: MESSAGE_ACTIONS.GENERATE_PROOF_RESPONSE,
@@ -93,6 +103,17 @@ class OffscreenProofGenerator {
               return;
             }
 
+            // Reported here, not on attestor resolution: the proof is only known
+            // good once the embedded-error check above has passed.
+            try {
+              await updateSessionStatus(sessionId, RECLAIM_SESSION_STATUS.PROOF_GENERATION_SUCCESS);
+            } catch (e) {
+              logger.error(
+                "[OFFSCREEN] Error updating status to PROOF_GENERATION_SUCCESS: " + e?.message,
+                "offscreen.proof",
+              );
+            }
+
             chrome.runtime.sendMessage({
               action: MESSAGE_ACTIONS.GENERATE_PROOF_RESPONSE,
               source: MESSAGE_SOURCES.OFFSCREEN,
@@ -101,7 +122,11 @@ class OffscreenProofGenerator {
               proof: proof,
             });
           } catch (error) {
-            logger.error("[OFFSCREEN] Error generating proof: " + error.message, "offscreen.proof");
+            logger.error(
+              "[OFFSCREEN] Error generating proof: " + error.message,
+              "offscreen.proof",
+              { eventType: EVENT_TYPES.PROOF_GENERATION_FAILED_EXCEPTION },
+            );
             chrome.runtime.sendMessage({
               action: MESSAGE_ACTIONS.GENERATE_PROOF_RESPONSE,
               source: MESSAGE_SOURCES.OFFSCREEN,
@@ -165,6 +190,10 @@ class OffscreenProofGenerator {
     const sessionId = claimData.sessionId;
     delete claimData.sessionId;
 
+    // Declared outside the try so the catch can read it — it was set here and
+    // never read anywhere, which is why nothing caught the scoping.
+    let timeoutOccurred = false;
+
     try {
       logger.info(
         "[OFFSCREEN] Updating session status to PROOF_GENERATION_STARTED",
@@ -172,8 +201,6 @@ class OffscreenProofGenerator {
       );
 
       await updateSessionStatus(sessionId, RECLAIM_SESSION_STATUS.PROOF_GENERATION_STARTED);
-
-      let timeoutOccurred = false;
 
       const timeoutPromise = new Promise((_, reject) => {
         setTimeout(() => {
@@ -186,11 +213,25 @@ class OffscreenProofGenerator {
         }, PROOF_GENERATION_TIMEOUT_MS);
       });
 
-      logger.debug("[OFFSCREEN] Final claimData for attestor", "offscreen.proof");
+      // This is the last point the claim is observable before attestor-core gets
+      // it: `sessionId` has been stripped above, and it has crossed the
+      // chrome-messaging boundary from the background. Logging only the message
+      // here left the object that actually reached the attestor invisible, which
+      // is the one thing an attestor-side rejection needs. Raw at FINE, redacted
+      // at the default INFO — see LoggingHub._addLog.
+      logger.debug("[OFFSCREEN] Final claimData for attestor", "offscreen.proof", {
+        payload: claimData,
+      });
 
-      const attestorPromise = await createClaimOnAttestor(claimData);
+      // NOT awaited here on purpose. Awaiting first and only then racing the
+      // timeout meant the race ran against an already-settled value, so
+      // PROOF_GENERATION_TIMEOUT_MS could never interrupt a hung attestor call
+      // — and the "promise created" line was logged after the call had already
+      // finished, landing in the same millisecond as the result and making the
+      // logs claim the call started 16s later than it did.
+      const attestorPromise = createClaimOnAttestor(claimData);
 
-      logger.info("[OFFSCREEN] Attestor promise created", "offscreen.proof");
+      logger.info("[OFFSCREEN] Attestor call started", "offscreen.proof");
 
       const result = await Promise.race([attestorPromise, timeoutPromise]);
 
@@ -198,12 +239,27 @@ class OffscreenProofGenerator {
 
       logger.info("[OFFSCREEN] Attestor promise result received", "offscreen.proof");
 
-      await updateSessionStatus(sessionId, RECLAIM_SESSION_STATUS.PROOF_GENERATION_SUCCESS);
+      // PROOF_GENERATION_SUCCESS is deliberately NOT reported here. The attestor
+      // can resolve with an error carried inside the result object, which only
+      // the caller checks. Reporting success on resolution meant a failed
+      // session recorded PROOF_GENERATION_SUCCESS and then
+      // PROOF_GENERATION_FAILED, so analytics claimed both outcomes for the same
+      // session. The caller now reports it once the proof is validated.
       return result;
     } catch (error) {
+      // `timeoutOccurred` distinguishes "the attestor took too long" from "the
+      // attestor threw", which are different problems with the same message
+      // prefix. This is the timeout that actually fires — the background's
+      // PROOF_RESPONSE_TIMEOUT_MS is deliberately longer, so it only sees a
+      // document that never answered.
       logger.error(
         "[OFFSCREEN] Error generating proof: " + (error?.message || "Unknown error"),
         "offscreen.proof",
+        {
+          eventType: timeoutOccurred
+            ? EVENT_TYPES.CLAIM_CREATION_TIMED_OUT_EXCEPTION
+            : EVENT_TYPES.PROOF_GENERATION_FAILED_EXCEPTION,
+        },
       );
       await updateSessionStatus(sessionId, RECLAIM_SESSION_STATUS.PROOF_GENERATION_FAILED);
       throw error;

--- a/src/scripts/install-assets.js
+++ b/src/scripts/install-assets.js
@@ -76,7 +76,6 @@ async function main() {
   console.log("[reclaim] copying circuits to public/browser-rpc/resources...");
   copyDir(zkResourcesDir, path.join(publicDir, "browser-rpc", "resources"));
 
-  // 2) Copy SDK assets into public/reclaim-browser-extension-sdk
   console.log("[reclaim] copying assets...");
   const targetBase = path.join(publicDir, "reclaim-browser-extension-sdk");
 
@@ -90,10 +89,8 @@ async function main() {
     path.join(targetBase, "content", "components"),
   );
 
-  // interceptor
   copyDir(path.join(sdkBuild, "interceptor"), path.join(targetBase, "interceptor"));
 
-  // offscreen
   copyDir(path.join(sdkBuild, "offscreen"), path.join(targetBase, "offscreen"));
 
   // snarkjs runtime

--- a/src/utils/claim-creator/attestor-extraction.js
+++ b/src/utils/claim-creator/attestor-extraction.js
@@ -1,0 +1,201 @@
+/**
+ * The attestor's response-redaction chain, adapted to return extracted values
+ * instead of reveal ranges.
+ *
+ * Mirrors `processRedactionRequest` in attestor-core
+ * `src/providers/http/index.ts` (a private generator, so it can't be vendored
+ * verbatim like ./vendor/attestor-http-utils.js). Keep the traversal order and
+ * offset arithmetic identical to upstream: `xPath` first, then `jsonPath`
+ * *within the element the xPath selected*, then `regex` within that. Getting
+ * the order or the offsets wrong yields a value that looks right but does not
+ * match the byte range the attestor reveals, and the claim then fails at the
+ * attestor with no useful error.
+ */
+
+import {
+  extractHTMLElementsIndexes,
+  extractJSONValueIndexes,
+  makeRegex,
+} from "./vendor/attestor-http-utils.js";
+
+export { makeRegex };
+
+/**
+ * A redaction that does not resolve against this particular response body.
+ * Distinct from a genuine error: it usually means the page hasn't rendered the
+ * data yet, so the caller should keep looking rather than fail the session.
+ */
+export class RedactionResolveError extends Error {
+  /**
+   * @param {string} message - selectors and shape only. MUST NOT embed response
+   *   content: this message becomes a `logLine` and is POSTed to the diagnostic
+   *   endpoint, where the user's authenticated page content has no business
+   *   being. Pass it as `element` instead — callers route that through the log
+   *   payload, which the console renders in full and the endpoint gets redacted.
+   * @param {object} [details]
+   * @param {"xPath"|"jsonPath"|"regex"|"redaction"} [details.stage] - which link
+   *   of the xPath -> jsonPath -> regex chain gave up. Lets the caller report
+   *   the specific failure (X_PATH_MATCH_REQUIREMENT_FAILED, …) instead of one
+   *   undifferentiated "did not resolve".
+   * @param {string} [details.element] - the content the stage was looking at.
+   */
+  constructor(message, { stage = "redaction", element } = {}) {
+    super(message);
+    this.name = "RedactionResolveError";
+    this.retryable = true;
+    this.stage = stage;
+    this.element = element;
+  }
+}
+
+/**
+ * Resolve one responseRedaction against a response body, following the
+ * attestor's xPath -> jsonPath -> regex chain.
+ *
+ * @param {string} body - full response body
+ * @param {{xPath?: string, jsonPath?: string, regex?: string, hash?: string}} rs
+ * @returns {{value: string, start: number, end: number}[]} one entry per match,
+ *  in upstream's yield order. For a hashed regex redaction the entry is the
+ *  named capture group only — that is the span the attestor hashes and reveals.
+ * @throws {RedactionResolveError} if the redaction does not resolve
+ */
+export function resolveRedaction(body, rs) {
+  const out = [];
+
+  let element = body;
+  let elementIdx = 0;
+  let elementLength = -1;
+  // Which link of the chain we are on, so a throw from the vendored extractors
+  // (which know nothing about this) can still be attributed to a stage.
+  let stage = "redaction";
+
+  try {
+    if (rs.xPath) {
+      stage = "xPath";
+      const indexes = extractHTMLElementsIndexes(body, rs.xPath, !!rs.jsonPath);
+      for (const { start, end } of indexes) {
+        element = body.slice(start, end);
+        elementIdx = start;
+        elementLength = end - start;
+        if (rs.jsonPath) {
+          processJsonPath();
+        } else if (rs.regex) {
+          processRegexp();
+        } else {
+          emit();
+        }
+      }
+    } else if (rs.jsonPath) {
+      processJsonPath();
+    } else if (rs.regex) {
+      processRegexp();
+    } else {
+      throw new Error("Expected either xPath, jsonPath or regex for redaction");
+    }
+  } catch (error) {
+    if (error instanceof RedactionResolveError) {
+      throw error;
+    }
+    throw new RedactionResolveError(error?.message || String(error), { stage });
+  }
+
+  if (!out.length) {
+    throw new RedactionResolveError(`Redaction resolved to nothing (${describeRedaction(rs)})`, {
+      stage,
+    });
+  }
+
+  return out;
+
+  function processJsonPath() {
+    stage = "jsonPath";
+    const jsonPathIndexes = extractJSONValueIndexes(element, rs.jsonPath);
+
+    const eIndex = elementIdx;
+    for (const ji of jsonPathIndexes) {
+      const jStart = ji.start;
+      const jEnd = ji.end;
+      element = body.slice(eIndex + jStart, eIndex + jEnd);
+      elementIdx = eIndex + jStart;
+      elementLength = jEnd - jStart;
+
+      if (rs.regex) {
+        processRegexp();
+      } else {
+        emit();
+      }
+    }
+  }
+
+  function processRegexp() {
+    stage = "regex";
+    const regexp = makeRegex(rs.regex);
+    const elem = element || body;
+    const match = regexp.exec(elem);
+
+    if (!match?.[0]) {
+      // The element text used to be interpolated into this message, which put up
+      // to 200 characters of the user's authenticated page into every log line
+      // shipped to the diagnostic endpoint. It travels as `element` now, so the
+      // caller can give it to the console without publishing it.
+      throw new RedactionResolveError(
+        `regexp ${rs.regex} does not match the selected element (element length: ${elem.length})`,
+        { stage: "regex", element: elem },
+      );
+    }
+
+    elementIdx += match.index;
+    elementLength = regexp.lastIndex - match.index;
+    element = match[0];
+
+    if (rs.hash && (!match.groups || Object.keys(match.groups).length > 1)) {
+      throw new Error("Exactly one named capture group is needed per hashed redaction");
+    }
+
+    // if there are groups in the regex, we'll only reveal the group values
+    if (!rs.hash || !match.groups) {
+      emit();
+      return;
+    }
+
+    // A hashed redaction reveals only the capture group, so that — not the
+    // whole regex match — is the value that has to land in paramValues.
+    const fullStr = match[0];
+    const grp = Object.values(match.groups)[0];
+    const grpIdx = fullStr.indexOf(grp);
+
+    elementIdx += grpIdx;
+    element = grp;
+    elementLength = grp.length;
+    emit();
+  }
+
+  function emit() {
+    if (elementIdx < 0 || !elementLength) {
+      return;
+    }
+    out.push({
+      value: element,
+      start: elementIdx,
+      end: elementIdx + elementLength,
+    });
+  }
+}
+
+/** First resolved slice, or throw. */
+export function resolveRedactionFirst(body, rs) {
+  return resolveRedaction(body, rs)[0];
+}
+
+export function describeRedaction(rs) {
+  const parts = [];
+  if (rs.xPath) parts.push(`xPath: ${rs.xPath}`);
+  if (rs.jsonPath) parts.push(`jsonPath: ${rs.jsonPath}`);
+  if (rs.regex) parts.push(`regex: ${rs.regex}`);
+  return parts.join(", ") || "empty redaction";
+}
+
+// `truncate()` lived here to cap response content spliced into an error
+// message. Nothing embeds response content in a message any more — it travels as
+// RedactionResolveError.element and is capped by the log layer on its way to the
+// endpoint — so the helper is gone rather than left as an invitation.

--- a/src/utils/claim-creator/attestor-extraction.test.js
+++ b/src/utils/claim-creator/attestor-extraction.test.js
@@ -122,7 +122,7 @@ describe("vendored attestor primitives", () => {
   });
 
   it("does not error on a catastrophic-looking regex", () => {
-    const regexp = makeRegex("([a-z]+)+$");
+    const regexp = makeRegex("^[a-z]+$");
     regexp.test("a".repeat(31) + "\x00");
   });
 

--- a/src/utils/claim-creator/attestor-extraction.test.js
+++ b/src/utils/claim-creator/attestor-extraction.test.js
@@ -122,7 +122,16 @@ describe("vendored attestor primitives", () => {
   });
 
   it("does not error on a catastrophic-looking regex", () => {
-    const regexp = makeRegex("^[a-z]+$");
+    // The catastrophic pattern is the INPUT UNDER TEST, not an accident.
+    // Upstream evaluates provider regexes with RE2, which cannot backtrack; we
+    // use `new RegExp` (webpack aliases re2 to false), which can. This pins
+    // what makeRegex does when handed a provider regex of that shape.
+    //
+    // CodeQL flags it as an inefficient regular expression and Copilot Autofix
+    // has once "fixed" it to `^[a-z]+$` — a linear pattern, which makes the
+    // test assert nothing at all. Do not simplify it.
+    // codeql[js/redos]
+    const regexp = makeRegex("([a-z]+)+$");
     regexp.test("a".repeat(31) + "\x00");
   });
 

--- a/src/utils/claim-creator/attestor-extraction.test.js
+++ b/src/utils/claim-creator/attestor-extraction.test.js
@@ -1,0 +1,369 @@
+/**
+ * Parity tests for the vendored attestor extraction code and the redaction
+ * chain built on top of it.
+ *
+ * The fixtures and expectations in "vendored primitives" are lifted from
+ * attestor-core's own `src/tests/http-provider-utils.test.ts`. That is the
+ * point: this file is the check you re-run after manually re-syncing
+ * ./vendor/attestor-http-utils.js from upstream, to prove the copy still agrees
+ * with the attestor. If a case here fails, a provider's xPath/jsonPath resolves
+ * differently in this extension than it does at the attestor and in the InApp
+ * SDK — which is the exact class of bug this code exists to prevent.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import {
+  extractHTMLElement,
+  extractHTMLElements,
+  extractJSONValueIndex,
+  extractJSONValueIndexes,
+} from "./vendor/attestor-http-utils.js";
+import { makeRegex } from "./make-regex.js";
+import { resolveRedaction, RedactionResolveError } from "./attestor-extraction.js";
+import { extractParamsFromResponse } from "./params-extractor.js";
+
+const NESTED_HTML = `<body>
+			  <div id="content123">This is <span>some</span> text!</div>
+			  <div id="content456">This is <span>some</span> other text!</div>
+			  <div id="content789">This is <span>some</span> irrelevant text!</div>
+			</body>`;
+
+const PHONE_JSON = `{
+    "firstName": "John",
+    "lastName": "doe",
+    "age": 26,
+    "address": {
+        "streetAddress": "naist street",
+        "city": "Nara",
+        "postalCode": "630-0192"
+    },
+    "phoneNumbers": [
+        {
+            "type": "iPhone",
+            "number": "0123-4567-8888"
+        },
+        {
+            "type": "home",
+            "number": "0123-4567-8910"
+        }
+    ]
+}`;
+
+// An HTML page with an embedded JSON island — the shape that could never work
+// before, because the old code treated xPath and jsonPath as mutually exclusive.
+const HTML_WITH_JSON = `<html><head><title>Top Links | Hacker News</title></head><body>
+  <script data-component-name="Navbar" type="application/json">{"hasBookface":true,"user":{"name":"providerreclaim","id":16935239}}</script>
+</body></html>`;
+
+describe("vendored attestor primitives", () => {
+  it("extracts inner and outer tag contents", () => {
+    assert.equal(
+      extractHTMLElement(NESTED_HTML, "//div[contains(@id, 'content123')]", true),
+      "This is <span>some</span> text!",
+    );
+    assert.equal(
+      extractHTMLElement(NESTED_HTML, "//div[contains(@id, 'content456')]", false),
+      '<div id="content456">This is <span>some</span> other text!</div>',
+    );
+  });
+
+  it("extracts multiple elements", () => {
+    assert.deepEqual(extractHTMLElements(NESTED_HTML, "//body/div", true), [
+      "This is <span>some</span> text!",
+      "This is <span>some</span> other text!",
+      "This is <span>some</span> irrelevant text!",
+    ]);
+  });
+
+  it("resolves an absolute xpath", () => {
+    assert.deepEqual(extractHTMLElements(HTML_WITH_JSON, "./html/head/title", true), [
+      "Top Links | Hacker News",
+    ]);
+  });
+
+  it("extracts multiple jsonPaths as raw slices", () => {
+    const indexes = extractJSONValueIndexes(PHONE_JSON, "$.phoneNumbers[*].number");
+    const res = indexes.map(({ start, end }) => PHONE_JSON.slice(start, end));
+    assert.deepEqual(res, ['"number": "0123-4567-8888"', '"number": "0123-4567-8910"']);
+  });
+
+  it("extracts a filter-expression jsonPath", () => {
+    const json = `{
+    "items":[
+        {
+            "name": "John Doe",
+            "country": "USA"
+        },
+        {
+          "country": "USA",
+          "age":25
+        }
+    ]
+}`;
+    const val = extractJSONValueIndex(json, "$.items[?(@.name.match(/.*oe/))].name");
+    assert.equal(json.slice(val.start, val.end), '"name": "John Doe"');
+  });
+
+  it("preserves the raw slice, not a re-serialized value", () => {
+    // The whole reason for the byte-range approach: key order and spacing in the
+    // response are load-bearing, because the attestor re-asserts the
+    // substituted template against the response bytes.
+    const val = extractJSONValueIndex(PHONE_JSON, "$.address.postalCode");
+    assert.equal(PHONE_JSON.slice(val.start, val.end), '"postalCode": "630-0192"');
+  });
+
+  it("throws on a missing xpath rather than returning undefined", () => {
+    assert.throws(
+      () => extractHTMLElement(NESTED_HTML, "//div[@id='nope']", true),
+      /Failed to find XPath/,
+    );
+  });
+
+  it("does not error on a catastrophic-looking regex", () => {
+    const regexp = makeRegex("([a-z]+)+$");
+    regexp.test("a".repeat(31) + "\x00");
+  });
+
+  it("uses the attestor's browser flag set", () => {
+    assert.equal(makeRegex("x").flags, "gis");
+    // `s` is the flag that matters most in practice: provider regexes routinely
+    // span newlines in HTML bodies.
+    assert.ok(makeRegex("a.b").test("a\nb"));
+  });
+});
+
+describe("redaction chain", () => {
+  it("chains xPath into jsonPath", () => {
+    const [slice] = resolveRedaction(HTML_WITH_JSON, {
+      xPath: "//script[@data-component-name='Navbar']",
+      jsonPath: "$.hasBookface",
+    });
+    assert.equal(slice.value, '"hasBookface":true');
+    // Offsets must be absolute against the full body, not the element.
+    assert.equal(HTML_WITH_JSON.slice(slice.start, slice.end), '"hasBookface":true');
+  });
+
+  it("chains xPath into jsonPath into regex", () => {
+    const [slice] = resolveRedaction(HTML_WITH_JSON, {
+      xPath: "//script[@data-component-name='Navbar']",
+      jsonPath: "$.user.name",
+      regex: '"name":"(.*?)"',
+    });
+    assert.equal(slice.value, '"name":"providerreclaim"');
+    assert.equal(HTML_WITH_JSON.slice(slice.start, slice.end), '"name":"providerreclaim"');
+  });
+
+  it("handles jsonPath alone", () => {
+    const [slice] = resolveRedaction(PHONE_JSON, { jsonPath: "$.firstName" });
+    assert.equal(slice.value, '"firstName": "John"');
+  });
+
+  it("handles xPath alone", () => {
+    const [slice] = resolveRedaction(NESTED_HTML, {
+      xPath: "//div[contains(@id, 'content123')]",
+    });
+    // contentsOnly is false when there's no jsonPath, matching upstream.
+    assert.equal(slice.value, '<div id="content123">This is <span>some</span> text!</div>');
+  });
+
+  it("handles regex alone", () => {
+    const [slice] = resolveRedaction(PHONE_JSON, { regex: '"city": "(.*?)"' });
+    assert.equal(slice.value, '"city": "Nara"');
+  });
+
+  it("returns one entry per match for a multi-node path", () => {
+    const slices = resolveRedaction(PHONE_JSON, { jsonPath: "$.phoneNumbers[*].number" });
+    assert.deepEqual(
+      slices.map((s) => s.value),
+      ['"number": "0123-4567-8888"', '"number": "0123-4567-8910"'],
+    );
+  });
+
+  it("narrows a hashed redaction to its capture group", () => {
+    const [slice] = resolveRedaction(PHONE_JSON, {
+      jsonPath: "$.firstName",
+      regex: '"firstName": "(?<who>.*?)"',
+      hash: "oprf",
+    });
+    // Only the group is revealed for a hashed redaction, so only the group can
+    // be the param value.
+    assert.equal(slice.value, "John");
+    assert.equal(PHONE_JSON.slice(slice.start, slice.end), "John");
+  });
+
+  it("rejects a hashed redaction with more than one group", () => {
+    assert.throws(
+      () =>
+        resolveRedaction(PHONE_JSON, {
+          regex: '"firstName": "(?<a>.*?)"(?<b>.*?)$',
+          hash: "oprf",
+        }),
+      /Exactly one named capture group/,
+    );
+  });
+
+  it("raises a retryable error when a path is absent", () => {
+    assert.throws(
+      () => resolveRedaction(PHONE_JSON, { jsonPath: "$.notThere" }),
+      (err) => err instanceof RedactionResolveError && err.retryable === true,
+    );
+  });
+
+  it("raises a retryable error when a regex does not match", () => {
+    assert.throws(
+      () => resolveRedaction(PHONE_JSON, { regex: "nothing-like-this" }),
+      (err) => err instanceof RedactionResolveError && err.retryable === true,
+    );
+  });
+
+  it("attributes the failure to the stage that gave up", () => {
+    // The caller reports X_PATH_/JSON_PATH_/REGEX_MATCH_REQUIREMENT_FAILED off
+    // this field. Without it every failure looked the same, so "this provider's
+    // regex broke" was indistinguishable from "its jsonPath broke".
+    const cases = [
+      [{ jsonPath: "$.notThere" }, "jsonPath"],
+      [{ regex: "nothing-like-this" }, "regex"],
+      [{ xPath: "//div[@id='nope']" }, "xPath"],
+    ];
+    for (const [redaction, expected] of cases) {
+      assert.throws(
+        () => resolveRedaction(PHONE_JSON, redaction),
+        (err) => err.stage === expected,
+        JSON.stringify(redaction),
+      );
+    }
+  });
+
+  it("keeps response content out of the error message", () => {
+    // The message becomes a logLine and is POSTed to the diagnostic endpoint.
+    // It used to interpolate up to 200 chars of the user's authenticated page.
+    const secret = "SUPER_PRIVATE_ACCOUNT_VALUE";
+    assert.throws(
+      () => resolveRedaction(`{"account":"${secret}"}`, { regex: "nothing-like-this" }),
+      (err) => {
+        assert.ok(!err.message.includes(secret), `message leaked content: ${err.message}`);
+        // Still reachable for the console, via the payload path.
+        assert.ok(err.element.includes(secret));
+        return true;
+      },
+    );
+  });
+
+  it("requires at least one of xPath/jsonPath/regex", () => {
+    assert.throws(
+      () => resolveRedaction(PHONE_JSON, {}),
+      /Expected either xPath, jsonPath or regex/,
+    );
+  });
+});
+
+describe("param extraction", () => {
+  it("derives a value from the raw slice via a contains template", () => {
+    const params = extractParamsFromResponse(
+      PHONE_JSON,
+      [{ value: '"firstName": "{{who}}"', type: "contains" }],
+      [{ jsonPath: "$.firstName" }],
+    );
+    assert.deepEqual(params, { who: "John" });
+  });
+
+  it("derives a value via a regex-type template", () => {
+    const params = extractParamsFromResponse(
+      PHONE_JSON,
+      [{ value: '"city":\\s*"{{city}}"', type: "regex" }],
+      [{ jsonPath: "$.address.city" }],
+    );
+    assert.deepEqual(params, { city: "Nara" });
+  });
+
+  it("extracts through an xPath+jsonPath chain", () => {
+    const params = extractParamsFromResponse(
+      HTML_WITH_JSON,
+      [{ value: '"name":"{{username}}"', type: "contains" }],
+      [{ xPath: "//script[@data-component-name='Navbar']", jsonPath: "$.user.name" }],
+    );
+    assert.deepEqual(params, { username: "providerreclaim" });
+  });
+
+  it("does not JSON.stringify an object value", () => {
+    // The old implementation returned JSON.stringify(parsedObject) here, whose
+    // spacing differs from the response bytes, so the attestor's re-assertion
+    // of the substituted template failed.
+    const params = extractParamsFromResponse(
+      PHONE_JSON,
+      [{ value: '"address": {{addr}}', type: "contains" }],
+      [{ jsonPath: "$.address" }],
+    );
+    assert.ok(PHONE_JSON.includes(`"address": ${params.addr}`));
+  });
+
+  it("takes the hashed group as the value", () => {
+    const params = extractParamsFromResponse(
+      PHONE_JSON,
+      [{ value: "{{secretName}}", type: "contains" }],
+      [{ jsonPath: "$.firstName", regex: '"firstName": "(?<who>.*?)"', hash: "oprf" }],
+    );
+    assert.deepEqual(params, { secretName: "John" });
+  });
+
+  it("throws retryably when an unknown param cannot be resolved", () => {
+    assert.throws(
+      () =>
+        extractParamsFromResponse(
+          PHONE_JSON,
+          [{ value: '"missing": "{{nope}}"', type: "contains" }],
+          [{ jsonPath: "$.missing" }],
+        ),
+      (err) => err.retryable === true,
+    );
+  });
+
+  it("tolerates an unresolvable redaction for an already-known param", () => {
+    // Custom injections supply values the declared templates can't express;
+    // those must survive a redaction that doesn't resolve.
+    const params = extractParamsFromResponse(
+      PHONE_JSON,
+      [{ value: '"missing": "{{nope}}"', type: "contains" }],
+      [{ jsonPath: "$.missing" }],
+      { nope: "from-injection" },
+    );
+    assert.deepEqual(params, { nope: "from-injection" });
+  });
+
+  it("ignores responseMatches with no placeholders", () => {
+    const params = extractParamsFromResponse(
+      PHONE_JSON,
+      [{ value: '"lastName": "doe"', type: "contains" }],
+      [{ jsonPath: "$.lastName" }],
+    );
+    assert.deepEqual(params, {});
+  });
+
+  it("falls back to positional groups for names that can't be capture groups", () => {
+    // `user-id` is not a valid JS identifier, so `(?<user-id>...)` is a regex
+    // syntax error. Those params must still be extracted, mapped by the order
+    // their placeholders appear in.
+    const params = extractParamsFromResponse(
+      PHONE_JSON,
+      [
+        {
+          value: '"type": "{{2fa-kind}}",\n            "number": "{{phone-no}}"',
+          type: "contains",
+        },
+      ],
+      [{ jsonPath: "$.phoneNumbers[0]" }],
+    );
+    assert.deepEqual(params, { "2fa-kind": "iPhone", "phone-no": "0123-4567-8888" });
+  });
+
+  it("extracts multiple params from one template", () => {
+    const params = extractParamsFromResponse(
+      PHONE_JSON,
+      [{ value: '"type": "{{kind}}",\n            "number": "{{num}}"', type: "contains" }],
+      [{ jsonPath: "$.phoneNumbers[0]" }],
+    );
+    assert.deepEqual(params, { kind: "iPhone", num: "0123-4567-8888" });
+  });
+});

--- a/src/utils/claim-creator/attestor-parity.test.js
+++ b/src/utils/claim-creator/attestor-parity.test.js
@@ -1,0 +1,133 @@
+/**
+ * Differential test: the vendored extraction code vs. the REAL attestor-core
+ * installed in node_modules.
+ *
+ * ./vendor/attestor-http-utils.js is a hand-maintained copy, so "it matches
+ * upstream" has to be checked, not assumed. Where possible this checks it
+ * against the actual installed package rather than against expectations copied
+ * out of upstream's test file.
+ *
+ * How it reaches the functions: the extractors aren't exported from the package
+ * root until 5.1.0 (PR #92). But the `./external-rpc` subpath is exported, and
+ * its `handleIncomingMessage` dispatches `extractHtmlElement` /
+ * `extractJSONValueIndex` straight to the same providers/http/utils.ts
+ * functions. So we drive the attestor through its own RPC surface and compare.
+ *
+ * AVAILABILITY: attestor-core's `lib/*.js` used to be esbuild bundles doing
+ * *named* imports from `@reclaimprotocol/tls`, which resolves to CommonJS.
+ * Node's ESM loader refuses that ("Named export 'asciiToUint8Array' not
+ * found"), so on 5.0.5 the package could not be loaded here at all and this
+ * file skipped. **5.1.1 ships `lib/` as ESM, so the check actually runs** —
+ * which is a large part of why that bump is worth having.
+ *
+ * The skip path is kept, not deleted: nothing stops a future pin from
+ * regressing to the CJS-named-import shape, and a skip with an explicit reason
+ * is the honest outcome there. Failing or, worse, silently passing is not.
+ *
+ * When it is skipped, parity is still covered — by the upstream-derived
+ * fixtures in ./attestor-extraction.test.js. This file is the stronger check
+ * when it can run; that file is the always-available one.
+ *
+ * RUN THIS AFTER EVERY MANUAL RE-SYNC of the vendored file, and check whether
+ * it reported "skipped" — a skip means the strong check did not run.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import { extractHTMLElement, extractJSONValueIndex } from "./vendor/attestor-http-utils.js";
+
+// handleIncomingMessage replies through globalThis[RPC_CHANNEL_NAME].postMessage
+const CHANNEL = "reclaim_ext_parity_test";
+let lastReply = null;
+
+globalThis.RPC_CHANNEL_NAME = CHANNEL;
+globalThis[CHANNEL] = {
+  postMessage: (str) => {
+    lastReply = JSON.parse(str);
+  },
+};
+
+let handleIncomingMessage = null;
+let unavailableReason = null;
+
+try {
+  ({ handleIncomingMessage } = await import("@reclaimprotocol/attestor-core/external-rpc"));
+} catch (error) {
+  unavailableReason = error?.message?.split("\n")[0] ?? String(error);
+}
+
+const attestor = async (type, request) => {
+  lastReply = null;
+  await handleIncomingMessage({ id: "parity", type, request });
+  if (!lastReply) throw new Error(`attestor sent no reply for ${type}`);
+  if (lastReply.type === "error") throw new Error(lastReply.data.message);
+  return lastReply.response;
+};
+
+const NESTED_HTML = `<body>
+			  <div id="content123">This is <span>some</span> text!</div>
+			  <div id="content456">This is <span>some</span> other text!</div>
+			</body>`;
+
+const HTML_WITH_JSON = `<html><head><title>Top Links | Hacker News</title></head><body>
+  <script data-component-name="Navbar" type="application/json">{"hasBookface":true,"user":{"name":"providerreclaim","id":16935239}}</script>
+</body></html>`;
+
+const NESTED_JSON = `{
+    "firstName": "John",
+    "address": { "city": "Nara", "postalCode": "630-0192" },
+    "phoneNumbers": [ { "type": "iPhone", "number": "0123-4567-8888" } ]
+}`;
+
+describe("parity with installed attestor-core", () => {
+  if (!handleIncomingMessage) {
+    it(
+      "SKIPPED — installed attestor-core cannot be loaded under Node, " +
+        "so the differential check did not run " +
+        `(${unavailableReason}). Parity is covered by attestor-extraction.test.js.`,
+      { skip: true },
+      () => {},
+    );
+    return;
+  }
+
+  const htmlCases = [
+    [NESTED_HTML, "//div[contains(@id, 'content123')]", true],
+    [NESTED_HTML, "//div[contains(@id, 'content456')]", false],
+    [NESTED_HTML, "//body/div", true],
+    [HTML_WITH_JSON, "./html/head/title", true],
+    [HTML_WITH_JSON, "//script[@data-component-name='Navbar']", true],
+    [HTML_WITH_JSON, "//script[@type='application/json']", false],
+  ];
+
+  for (const [html, xpathExpression, contentsOnly] of htmlCases) {
+    it(`xPath ${xpathExpression} (contentsOnly=${contentsOnly})`, async () => {
+      assert.equal(
+        extractHTMLElement(html, xpathExpression, contentsOnly),
+        await attestor("extractHtmlElement", { html, xpathExpression, contentsOnly }),
+      );
+    });
+  }
+
+  const jsonCases = [
+    [NESTED_JSON, "$.firstName"],
+    [NESTED_JSON, "$.address"],
+    [NESTED_JSON, "$.address.city"],
+    [NESTED_JSON, "$.address.postalCode"],
+    [NESTED_JSON, "$.phoneNumbers[0].number"],
+    ['{"hasBookface":true,"user":{"name":"providerreclaim","id":16935239}}', "$.user.name"],
+  ];
+
+  for (const [json, jsonPath] of jsonCases) {
+    it(`jsonPath ${jsonPath}`, async () => {
+      const mine = extractJSONValueIndex(json, jsonPath);
+      const theirs = await attestor("extractJSONValueIndex", { json, jsonPath });
+
+      // Byte ranges must agree exactly — the range is what the attestor
+      // reveals, so an off-by-one produces a claim the attestor rejects.
+      assert.deepEqual(mine, theirs);
+      assert.equal(json.slice(mine.start, mine.end), json.slice(theirs.start, theirs.end));
+    });
+  }
+});

--- a/src/utils/claim-creator/attestor-zk-engine.test.js
+++ b/src/utils/claim-creator/attestor-zk-engine.test.js
@@ -1,0 +1,93 @@
+/**
+ * Guard: the pinned attestor-core's prebuilt browser bundle must register a ZK
+ * operator maker for the engine we default to.
+ *
+ * Why this exists. `browser/resources/attestor-browser.min.mjs` is a checked-in
+ * build artifact upstream, produced by a separate `npm run build:browser` step
+ * from the rest of the package. Its contents have changed *silently* between
+ * patch releases:
+ *
+ *   version       ./browser ships   registers 'stwo'
+ *   5.0.5         yes               yes
+ *   5.0.6         yes               NO
+ *   5.0.7         yes               NO
+ *   5.0.8         yes               NO
+ *   5.1.0-dev.1   yes               yes
+ *   5.1.0         NO (404)          n/a
+ *   5.1.1         yes               yes   <- current pin
+ *
+ * A bump into 5.0.6–5.0.8 produces no install error, no build error and no test
+ * failure — it fails at runtime, deep in the offscreen document, as
+ * "Proof generation failed: No ZK operator maker for stwo", after the user has
+ * already logged into the provider. That is an expensive way to find out.
+ *
+ * So this asserts it statically against the shipped artifact. It is deliberately
+ * a string check on the bundle rather than an attempt to instantiate the
+ * operator: instantiating needs WASM, a circuit fetcher and the zk resources
+ * copied into a consumer's public/ folder, none of which exist in a unit test.
+ * The bundle either contains the engine's registration or it doesn't.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { DEFAULT_ZK_ENGINE } from "../constants/config.js";
+
+const require = createRequire(import.meta.url);
+
+// Resolve via the package's own entry, then walk up: the `exports` map blocks
+// direct access to package.json (same trick install-assets.js uses).
+const resolvePackageDir = (pkg) => {
+  let dir = path.dirname(require.resolve(pkg));
+  while (dir !== path.dirname(dir)) {
+    try {
+      readFileSync(path.join(dir, "package.json"));
+      return dir;
+    } catch {
+      dir = path.dirname(dir);
+    }
+  }
+  throw new Error(`could not locate ${pkg}`);
+};
+
+describe("attestor browser bundle ZK engine support", () => {
+  const pkgDir = resolvePackageDir("@reclaimprotocol/attestor-core");
+  const { version } = JSON.parse(readFileSync(path.join(pkgDir, "package.json"), "utf8"));
+  const bundlePath = path.join(pkgDir, "browser", "resources", "attestor-browser.min.mjs");
+
+  it("ships the browser bundle offscreen.js imports", () => {
+    // 5.1.0 dropped this file while still declaring exports['./browser'].
+    assert.doesNotThrow(
+      () => readFileSync(bundlePath),
+      `attestor-core@${version} does not ship browser/resources/attestor-browser.min.mjs, ` +
+        `which src/offscreen/offscreen.js imports as '@reclaimprotocol/attestor-core/browser'`,
+    );
+  });
+
+  it(`registers a ZK operator maker for the default engine (${DEFAULT_ZK_ENGINE})`, () => {
+    const bundle = readFileSync(bundlePath, "utf8");
+    const hits = bundle.split(DEFAULT_ZK_ENGINE).length - 1;
+
+    assert.ok(
+      hits > 0,
+      `attestor-core@${version}'s browser bundle contains no reference to ` +
+        `'${DEFAULT_ZK_ENGINE}', so createClaimOnAttestor will throw ` +
+        `"No ZK operator maker for ${DEFAULT_ZK_ENGINE}" at proof time. ` +
+        `Pin a version whose browser bundle supports it (5.0.5 does).`,
+    );
+  });
+
+  it("still contains the error we would otherwise hit at runtime", () => {
+    // Sanity check on the detection method: if upstream ever renames this
+    // error, the assertion above could pass for the wrong reason.
+    const bundle = readFileSync(bundlePath, "utf8");
+    assert.ok(
+      bundle.includes("No ZK operator maker for"),
+      "attestor-core's ZK operator lookup no longer throws the error this guard " +
+        "was written against — re-check how engine support is detected.",
+    );
+  });
+});

--- a/src/utils/claim-creator/claim-creator.js
+++ b/src/utils/claim-creator/claim-creator.js
@@ -3,12 +3,14 @@ import {
   extractParamsFromBody,
   extractParamsFromResponse,
   separateParams,
-  getHashedParamNames,
 } from "./params-extractor";
 import { MESSAGE_ACTIONS, MESSAGE_SOURCES } from "../constants";
 import { ensureOffscreenDocument } from "../offscreen-manager";
 import { getUserLocationBasedOnIp } from "./get-dynamic-geo";
-import { PRIVATE_KEY_TIMEOUT_MS } from "../constants/config";
+import { PRIVATE_KEY_TIMEOUT_MS, DEFAULT_ZK_ENGINE } from "../constants/config";
+import { EVENT_TYPES } from "../logger/constants";
+import { normalizeRedactionHash } from "../provider-normalization";
+import { assertClaimShape } from "./claim-shape";
 
 // Generate Chrome Android user agent (adapted from reference code)
 const generateChromeAndroidUserAgent = (chromeMajorVersion = 135, isMobile = true) => {
@@ -109,12 +111,16 @@ export const createClaimObject = async (
   loggingHub,
   context,
 ) => {
-  loggingHub.info("[CLAIM-CREATOR] Creating claim object from request data", "claim.creation");
+  loggingHub.info("[CLAIM-CREATOR] Creating claim object from request data", "claim.creation", {
+    eventType: EVENT_TYPES.PREPARING_CLAIM,
+  });
 
   // Ensure offscreen document is ready
   try {
     await ensureOffscreenDocument(loggingHub);
-    loggingHub.info("[CLAIM-CREATOR] Offscreen document is ready.", "claim.creation");
+    loggingHub.info("[CLAIM-CREATOR] Offscreen document is ready.", "claim.creation", {
+      eventType: EVENT_TYPES.OFFSCREEN_DOCUMENT_READY,
+    });
   } catch (error) {
     loggingHub.error(
       "[CLAIM-CREATOR] Failed to ensure offscreen document: " + error?.message,
@@ -201,7 +207,6 @@ export const createClaimObject = async (
     }
   }
 
-  // Process cookie string if available in request
   if (request.cookieStr) {
     secretParams.cookieStr = request.cookieStr;
   }
@@ -229,18 +234,21 @@ export const createClaimObject = async (
     };
   }
 
-  // 3. Extract params from response if available
+  // 3. Extract params from response if available.
+  // allParamValues is passed in as the accumulator so params already derived
+  // above (or supplied by a custom injection) count as satisfied — a redaction
+  // that can't resolve for an already-known param must not abort the claim.
+  // A RedactionResolveError for an *unknown* param propagates on purpose: it
+  // means the response doesn't carry the data yet, and the caller treats that
+  // as retryable rather than failing the session.
   if (request.responseText && providerData.responseMatches) {
-    // append the extracted parameters to the existing allParamValues
-    const extractedParams = extractParamsFromResponse(
+    allParamValues = extractParamsFromResponse(
       request.responseText,
       providerData.responseMatches,
       providerData.responseRedactions || [],
+      allParamValues,
+      loggingHub,
     );
-    allParamValues = {
-      ...allParamValues,
-      ...extractedParams,
-    };
   }
 
   // 4. Explicit extractedParams (e.g. from a customInjection request
@@ -251,18 +259,25 @@ export const createClaimObject = async (
     allParamValues = { ...allParamValues, ...request.extractedParams };
   }
 
-  // 5. Separate parameters into public and secret. Any param whose
-  // responseRedaction has a hash (oprf, etc.) must stay out of the public
-  // claim regardless of naming — extractParamsFromResponse extracts it
-  // independently of hash, so naming alone can't be trusted to keep it secret.
-  const hashedParamNames = getHashedParamNames(
-    providerData.responseMatches,
-    providerData.responseRedactions,
-  );
-  const { publicParams, secretParams: secretParamValues } = separateParams(
-    allParamValues,
-    hashedParamNames,
-  );
+  // 5. Separate parameters into public and secret, by NAME only — matching
+  // InApp's `_getHttpParams`/`_getSecretParams`, which split on the name
+  // containing "SECRET" and nothing else.
+  //
+  // Hash-bearing params are deliberately NOT forced secret. It reads like a
+  // privacy win, but it breaks OPRF outright:
+  //
+  //  - `secretParams.paramValues` is documented as substituting {{param}} in
+  //    the BODY only. A param referenced from `responseMatches` has to be in
+  //    `params.paramValues` or the attestor cannot substitute it and the match
+  //    fails.
+  //  - `updateParametersFromOprfData` (default true in attestor-core
+  //    client/create-claim.ts) rewrites `params` — and only `params` —
+  //    replacing the raw value with the OPRF nullifier. A value parked in
+  //    secretParams is never reached, so no hash is ever substituted.
+  //
+  // The privacy guarantee for a hashed param comes from that substitution
+  // happening client-side before the claim is sent, not from hiding the param.
+  const { publicParams, secretParams: secretParamValues } = separateParams(allParamValues);
 
   // Add parameter values to respective objects
   if (Object.keys(publicParams).length > 0) {
@@ -273,7 +288,6 @@ export const createClaimObject = async (
     secretParams.paramValues = secretParamValues;
   }
 
-  // Process response matches if available
   if (providerData.responseMatches) {
     params.responseMatches = providerData.responseMatches.map((match) => {
       // Create a clean object with only the required fields
@@ -287,64 +301,43 @@ export const createClaimObject = async (
     });
   }
 
-  // Process response redactions if available
+  // Process response redactions if available.
+  //
+  // Built as an ALLOWLIST of the four fields the attestor's schema declares.
+  // That schema is `additionalProperties: false` and is enforced server-side by
+  // AJV (attestor-core server/utils/validation.ts), so one stray key — real
+  // provider documents ship `order`, and `description`/`isOptional` appear on
+  // sibling structures — fails the whole claim with "Params validation failed",
+  // at proof time, after the user has logged in. A denylist cannot be kept in
+  // sync with a provider schema that grows independently of this SDK.
   if (providerData.responseRedactions) {
-    const EXCLUDED_REDACTION_FIELDS = ["order", "id"];
-
     params.responseRedactions = providerData.responseRedactions.map((redaction) => {
-      // Create a new object without hash field and empty jsonPath/xPath
       const cleanedRedaction = {};
 
-      Object.entries(redaction).forEach(([key, value]) => {
-        // Skip fields the attestor does not read
-        if (EXCLUDED_REDACTION_FIELDS.includes(key)) {
-          return;
+      // Empty xPath/jsonPath are omitted rather than sent as "": provider
+      // documents use "" for "not set", and the attestor would try to resolve it.
+      for (const key of ["xPath", "jsonPath", "regex"]) {
+        if (redaction?.[key]) {
+          cleanedRedaction[key] = redaction[key];
         }
+      }
 
-        // Skip empty jsonPath and xPath
-        if ((key === "jsonPath" || key === "xPath") && (!value || value === "")) {
-          return;
-        }
-
-        // Include hash if it has a value, skip if null/undefined
-        if (key === "hash") {
-          if (value) {
-            cleanedRedaction[key] = value;
-          }
-          return;
-        }
-
-        // Keep all other fields
-        cleanedRedaction[key] = value;
-      });
+      // Only `oprf-raw` is supported here; anything else is coerced.
+      const hash = normalizeRedactionHash(redaction?.hash, loggingHub);
+      if (hash) {
+        cleanedRedaction.hash = hash;
+      }
 
       return cleanedRedaction;
     });
   }
 
-  // Process response selections if available
-  if (providerData.responseSelections) {
-    params.responseSelections = providerData.responseSelections.map((selection) => {
-      // Only include value, type, and invert fields
-      const cleanedSelection = {};
+  // NOTE: `responseSelections` is deliberately NOT copied into params. It is a
+  // legacy provider field with no counterpart in the attestor's
+  // HttpProviderParameters schema, and that schema is `additionalProperties:
+  // false` — so including it made every claim for such a provider fail
+  // validation at the attestor. InApp does not send it either.
 
-      if ("value" in selection) {
-        cleanedSelection.value = selection.value;
-      }
-
-      if ("type" in selection) {
-        cleanedSelection.type = selection.type;
-      }
-
-      if ("invert" in selection) {
-        cleanedSelection.invert = selection.invert;
-      }
-
-      return cleanedSelection;
-    });
-  }
-
-  // Add any additional client options if available
   if (providerData.additionalClientOptions) {
     params.additionalClientOptions = providerData.additionalClientOptions;
   }
@@ -374,14 +367,20 @@ export const createClaimObject = async (
 
   params.geoLocation = geoLocation;
 
-  // Create the final claim object
+  // Last gate before the attestor. Both schemas are `additionalProperties:
+  // false` and AJV-enforced server-side, so an unexpected key means
+  // "ERROR_BAD_REQUEST: Params validation failed" at proof time — after the
+  // user has logged in, with nothing in the message naming the offending field.
+  // Catching it here turns that into an actionable local log.
+  assertClaimShape(params, secretParams, loggingHub);
+
   const claimObject = {
     name: "http",
     sessionId: sessionId,
     params,
     secretParams,
     ownerPrivateKey: ownerPrivateKey,
-    zkEngine: providerData?.extensionConfig?.zkEngine || "stwo",
+    zkEngine: providerData?.extensionConfig?.zkEngine || DEFAULT_ZK_ENGINE,
     client: {
       url: "wss://attestor.reclaimprotocol.org:444/ws",
     },
@@ -393,10 +392,20 @@ export const createClaimObject = async (
     claimObject.context = context;
   }
 
-  loggingHub.debug(
-    "[CLAIM-CREATOR] Claim object: " + JSON.stringify(claimObject, null, 2),
-    "claim.creation",
-  );
+  // The full claim. A claim rejected by the attestor ("Params validation
+  // failed", a response match that never matches) can only be diagnosed from
+  // the exact bytes that were sent, and the redacted form blanks `secretParams`,
+  // `paramValues` and `ownerPrivateKey` — the fields most likely to be at fault.
+  //
+  // At FINE this is the raw object; at the default INFO it is redacted, and
+  // `ownerPrivateKey` and the user's live session cookies never leave the
+  // device. No per-call opt-out is involved any more: the level decides.
+  //
+  // Still pass the OBJECT rather than stringifying here — stringifying at the
+  // call site would push the raw claim past redaction at every level.
+  loggingHub.debug("[CLAIM-CREATOR] Claim object:", "claim.creation", {
+    payload: claimObject,
+  });
 
   return claimObject;
 };

--- a/src/utils/claim-creator/claim-creator.test.js
+++ b/src/utils/claim-creator/claim-creator.test.js
@@ -1,179 +1,157 @@
-/* eslint-disable */
-/*
- * This file contains tests that are only meant to be run in a test environment.
+/**
+ * Tests for the URL / body / naming halves of params-extractor.
  *
- * DO NOT IMPORT THIS FILE IN PRODUCTION CODE.
- * It's excluded from index.js exports to prevent production issues.
+ * This file used to be a no-op: it stubbed `test`/`describe`/`expect` when they
+ * were undefined and only `require`d the modules under
+ * `typeof jest !== 'undefined'`, so with no Jest installed it asserted nothing
+ * while still reporting green. The cases below are the same scenarios it
+ * described, now actually executed.
+ *
+ * Response extraction lives in ./attestor-extraction.test.js; parity with the
+ * installed attestor lives in ./attestor-parity.test.js.
+ *
+ * `createClaimObject` itself is not covered here — it needs chrome.* and a live
+ * offscreen document for the owner private key, so it belongs in the
+ * load-unpacked end-to-end pass, not a unit test.
  */
 
-// These dummy declarations prevent bundlers from showing errors
-// when they don't have access to Jest globals
-const dummyTest = () => {};
-const dummyDescribe = () => {};
-const dummyExpect = () => ({
-  toEqual: () => {},
-  toHaveProperty: () => {},
-});
+import { describe, it } from "node:test";
+import assert from "node:assert";
 
-// Use the real globals if they exist, otherwise use the dummy functions
-const testFn = typeof test !== "undefined" ? test : dummyTest;
-const describeFn = typeof describe !== "undefined" ? describe : dummyDescribe;
-const expectFn = typeof expect !== "undefined" ? expect : dummyExpect;
+import {
+  extractDynamicParamNames,
+  extractParamsFromUrl,
+  extractParamsFromBody,
+  getHashedParamNames,
+  separateParams,
+} from "./params-extractor.js";
 
-// For real test environments, import the modules
-let createClaimObject;
-let extractDynamicParamNames;
-let extractParamsFromUrl;
-let extractParamsFromBody;
-let extractParamsFromResponse;
-
-// Only load modules in a test environment
-if (typeof jest !== "undefined") {
-  try {
-    const claimCreator = require("./claim-creator");
-    const paramsExtractor = require("./params-extractor");
-
-    createClaimObject = claimCreator.createClaimObject;
-    extractDynamicParamNames = paramsExtractor.extractDynamicParamNames;
-    extractParamsFromUrl = paramsExtractor.extractParamsFromUrl;
-    extractParamsFromBody = paramsExtractor.extractParamsFromBody;
-    extractParamsFromResponse = paramsExtractor.extractParamsFromResponse;
-  } catch (e) {
-    console.error("Error loading test modules:", e);
-  }
-}
-
-// Tests for params-extractor.js
-describeFn("Params Extractor", () => {
-  testFn("Extract dynamic parameter names from a string", () => {
-    const template = "This is a {{param1}} with {{param2}} values";
-    const result = extractDynamicParamNames(template);
-    expectFn(result).toEqual(["param1", "param2"]);
+describe("extractDynamicParamNames", () => {
+  it("pulls every placeholder name out of a template", () => {
+    assert.deepEqual(extractDynamicParamNames("This is a {{param1}} with {{param2}} values"), [
+      "param1",
+      "param2",
+    ]);
   });
 
-  testFn("Extract parameters from URL", () => {
-    const urlTemplate = "https://example.com/users/{{userId}}/profile";
-    const actualUrl = "https://example.com/users/12345/profile";
-    const result = extractParamsFromUrl(urlTemplate, actualUrl);
-    expectFn(result).toEqual({ userId: "12345" });
-  });
-
-  testFn("Extract parameters from request body", () => {
-    const bodyTemplate = '{"username":"{{username}}","password":"{{password}}"}';
-    const actualBody = '{"username":"johndoe","password":"secret123"}';
-    const result = extractParamsFromBody(bodyTemplate, actualBody);
-    expectFn(result).toEqual({ username: "johndoe", password: "secret123" });
-  });
-
-  testFn("Extract parameters from JSON response", () => {
-    const responseText =
-      '{"id":16935239,"displayName":"Provider Reclaim","email":"providers@creatoros.co","userName":"providerreclaim"}';
-    const responseMatches = [
-      {
-        value: '"userName":"{{username}}"',
-        type: "contains",
-        invert: false,
-      },
-    ];
-    const responseRedactions = [
-      {
-        jsonPath: "$.userName",
-        regex: '"userName":"(.*)"',
-      },
-    ];
-
-    const result = extractParamsFromResponse(responseText, responseMatches, responseRedactions);
-    expectFn(result).toEqual({ username: "providerreclaim" });
+  it("returns an empty array for a template with no placeholders", () => {
+    assert.deepEqual(extractDynamicParamNames("nothing here"), []);
+    assert.deepEqual(extractDynamicParamNames(""), []);
+    assert.deepEqual(extractDynamicParamNames(undefined), []);
   });
 });
 
-// Tests for claim-creator.js
-describeFn("Claim Creator", () => {
-  testFn("Creates a basic claim object with necessary fields", () => {
-    const request = {
-      url: "https://example.com/api/data",
-      method: "GET",
-      headers: {
-        "user-agent": "Mozilla/5.0",
-        authorization: "Bearer token123",
-      },
-    };
-
-    const providerData = {};
-
-    const claim = createClaimObject(request, providerData);
-
-    expectFn(claim).toHaveProperty("name", "http");
-    expectFn(claim).toHaveProperty("params.url", "https://example.com/api/data");
-    expectFn(claim).toHaveProperty("params.method", "GET");
-    expectFn(claim).toHaveProperty("params.headers.user-agent", "Mozilla/5.0");
-    expectFn(claim).toHaveProperty("secretParams.headers.authorization", "Bearer token123");
-    expectFn(claim).toHaveProperty("ownerPrivateKey");
-    expectFn(claim).toHaveProperty("client.url");
+describe("extractParamsFromUrl", () => {
+  it("extracts a path segment", () => {
+    assert.deepEqual(
+      extractParamsFromUrl(
+        "https://example.com/users/{{userId}}/profile",
+        "https://example.com/users/12345/profile",
+      ),
+      { userId: "12345" },
+    );
   });
 
-  testFn("Extracts dynamic parameters from provider data", () => {
-    const responseText =
-      '{"id":16935239,"displayName":"Provider Reclaim","email":"providers@creatoros.co","userName":"providerreclaim"}';
-
-    const request = {
-      url: "https://api.example.com/users/12345",
-      body: '{"query":"get user details"}',
-      responseText,
-    };
-
-    const providerData = {
-      urlTemplate: "https://api.example.com/users/{{userId}}",
-      bodyTemplate: '{"query":"{{queryType}}"}',
-      responseMatches: [
-        {
-          value: '"userName":"{{username}}"',
-          type: "contains",
-          invert: false,
-        },
-      ],
-      responseRedactions: [
-        {
-          jsonPath: "$.userName",
-          regex: '"userName":"(.*)"',
-        },
-      ],
-    };
-
-    const claim = createClaimObject(request, providerData);
-
-    expectFn(claim.params.paramValues).toHaveProperty("userId", "12345");
-    expectFn(claim.params.paramValues).toHaveProperty("queryType", "get user details");
-    expectFn(claim.params.paramValues).toHaveProperty("username", "providerreclaim");
+  it("extracts multiple segments", () => {
+    assert.deepEqual(
+      extractParamsFromUrl(
+        "https://example.com/{{org}}/repos/{{repo}}",
+        "https://example.com/reclaim/repos/browser-sdk",
+      ),
+      { org: "reclaim", repo: "browser-sdk" },
+    );
   });
 
-  testFn("Separates secret parameters into secretParams.paramValues", () => {
-    const request = {
-      url: "https://api.example.com/users/12345",
-    };
+  it("returns the accumulator untouched when the URL does not match", () => {
+    assert.deepEqual(
+      extractParamsFromUrl(
+        "https://example.com/users/{{userId}}/profile",
+        "https://other.com/nope",
+      ),
+      {},
+    );
+  });
 
-    const providerData = {
-      urlTemplate: "https://api.example.com/users/{{userId}}",
-      paramValues: {
-        SECRET_token: "abc123",
-        normalParam: "value123",
-      },
-    };
-
-    const claim = createClaimObject(request, providerData);
-
-    expectFn(claim.params.paramValues).toHaveProperty("userId", "12345");
-    expectFn(claim.params.paramValues).toHaveProperty("normalParam", "value123");
-    expectFn(claim.params.paramValues).not.toHaveProperty("SECRET_token");
-
-    expectFn(claim.secretParams.paramValues).toHaveProperty("SECRET_token", "abc123");
+  it("no-ops on missing input", () => {
+    assert.deepEqual(extractParamsFromUrl("", "https://example.com"), {});
+    assert.deepEqual(extractParamsFromUrl("https://example.com/{{a}}", ""), {});
   });
 });
 
-// This is just a placeholder to prevent the actual tests from running in this file
-// Remove this line when running actual tests
-global.test =
-  global.test ||
-  ((name, fn) => {
-    /* no-op */
+describe("extractParamsFromBody", () => {
+  it("extracts placeholders from a JSON body template", () => {
+    // Also a regression guard on regex flags: the template's literal braces are
+    // not escaped by convertTemplateToRegex, which is only valid because
+    // makeRegex omits the `u` flag (mirroring the attestor's browser fallback).
+    // Adding `u` would make this throw.
+    assert.deepEqual(
+      extractParamsFromBody(
+        '{"username":"{{username}}","password":"{{password}}"}',
+        '{"username":"johndoe","password":"secret123"}',
+      ),
+      { username: "johndoe", password: "secret123" },
+    );
   });
+
+  it("no-ops when the body does not match the template", () => {
+    assert.deepEqual(extractParamsFromBody('{"username":"{{username}}"}', "totally different"), {});
+  });
+});
+
+describe("getHashedParamNames", () => {
+  it("collects params whose paired redaction is hashed", () => {
+    const names = getHashedParamNames(
+      [{ value: '"a":"{{plain}}"' }, { value: '"b":"{{hashed}}"' }],
+      [{ jsonPath: "$.a" }, { jsonPath: "$.b", hash: "oprf" }],
+    );
+    assert.deepEqual([...names], ["hashed"]);
+  });
+
+  it("returns an empty set when nothing is hashed", () => {
+    assert.equal(getHashedParamNames([{ value: "{{a}}" }], [{ jsonPath: "$.a" }]).size, 0);
+    assert.equal(getHashedParamNames(null, null).size, 0);
+  });
+});
+
+describe("separateParams", () => {
+  it("routes name-based secrets to secretParams", () => {
+    const { publicParams, secretParams } = separateParams({
+      SECRET_token: "abc123",
+      normalParam: "value123",
+    });
+    assert.deepEqual(publicParams, { normalParam: "value123" });
+    assert.deepEqual(secretParams, { SECRET_token: "abc123" });
+  });
+
+  it("still supports an explicit force-secret set", () => {
+    // The capability remains, but claim-creator no longer feeds hashed params
+    // into it — see the next test for why.
+    const { publicParams, secretParams } = separateParams(
+      { innocuousName: "sensitive", other: "fine" },
+      new Set(["innocuousName"]),
+    );
+    assert.deepEqual(publicParams, { other: "fine" });
+    assert.deepEqual(secretParams, { innocuousName: "sensitive" });
+  });
+
+  it("keeps an OPRF-hashed param PUBLIC when no force-set is given", () => {
+    // Regression guard. Forcing hash-bearing params into secretParams reads
+    // like a privacy win and breaks OPRF two ways:
+    //
+    //  1. The attestor verifies response matches via
+    //     substituteParamValues(rawParams, undefined, true) — secretParams is
+    //     UNDEFINED there, and ignoreMissingParams makes an unresolved
+    //     placeholder return literally. So `"displayName":"{{displayName}}"`
+    //     is matched verbatim against the response and never matches.
+    //  2. updateParametersFromOprfData (default true) replaces the raw value
+    //     with the OPRF nullifier inside `params` only, so a value parked in
+    //     secretParams never gets hashed at all.
+    //
+    // Privacy for a hashed param comes from that substitution happening
+    // client-side before the claim is sent — not from hiding the param.
+    // InApp does the same: it splits on the name containing "SECRET", nothing else.
+    const { publicParams, secretParams } = separateParams({ displayName: "sajjad" });
+    assert.deepEqual(publicParams, { displayName: "sajjad" });
+    assert.deepEqual(secretParams, {});
+  });
+});

--- a/src/utils/claim-creator/claim-shape.js
+++ b/src/utils/claim-creator/claim-shape.js
@@ -1,0 +1,101 @@
+/**
+ * Shape gate for the claim handed to the attestor.
+ *
+ * `params` and `secretParams` are validated server-side by AJV against
+ * attestor-core's `HttpProviderParameters` / `HttpProviderSecretParameters`
+ * schemas (see `server/utils/validation.ts`). Both are
+ * `additionalProperties: false` and AJV runs with `strict: true` and no
+ * `removeAdditional`, so a single unexpected key fails the entire claim with
+ * `ERROR_BAD_REQUEST: Params validation failed` — at proof time, after the user
+ * has logged into the provider, and with the offending field named only inside
+ * an opaque errors blob.
+ *
+ * Provider documents legitimately carry fields this SDK must not forward
+ * (`order`, `description`, `isOptional`, the legacy `responseSelections`), and
+ * that set grows independently of this SDK. So the gate is an allowlist taken
+ * from the schema rather than a denylist of known-bad keys.
+ *
+ * Kept in its own module with no imports so it is unit-testable: claim-creator.js
+ * pulls in chrome.* and the offscreen document and cannot load under Node.
+ */
+
+/**
+ * Keys the attestor's `HttpProviderParameters` schema declares. Mirrored by
+ * hand from attestor-core `src/types/providers.gen.ts`; the schema is
+ * `additionalProperties: false`, so this list is exhaustive by definition.
+ * Re-sync alongside the vendored extraction code.
+ */
+const ALLOWED_PARAM_KEYS = new Set([
+  "url",
+  "method",
+  "geoLocation",
+  "proxySessionId",
+  "headers",
+  "body",
+  "writeRedactionMode",
+  "additionalClientOptions",
+  "responseMatches",
+  "responseRedactions",
+  "paramValues",
+]);
+
+/** Keys the attestor's `HttpProviderSecretParameters` schema declares. */
+const ALLOWED_SECRET_PARAM_KEYS = new Set([
+  "cookieStr",
+  "authorisationHeader",
+  "headers",
+  "paramValues",
+]);
+
+/**
+ * Strip anything the attestor's schema would reject, coerce paramValues to
+ * strings, and shout about required fields that are missing.
+ *
+ * Mutates in place — the caller has already assembled the objects, and a copy
+ * would just have to be threaded through the claim construction below.
+ *
+ * @param {Object} params
+ * @param {Object} secretParams
+ * @param {Object} loggingHub
+ */
+export function assertClaimShape(params, secretParams, loggingHub) {
+  for (const [target, allowed, label] of [
+    [params, ALLOWED_PARAM_KEYS, "params"],
+    [secretParams, ALLOWED_SECRET_PARAM_KEYS, "secretParams"],
+  ]) {
+    const stray = Object.keys(target).filter((key) => !allowed.has(key));
+    if (stray.length) {
+      // Stripped rather than thrown: dropping an unknown field still produces
+      // a claim the attestor accepts, whereas failing the session would deny a
+      // verification over a field the attestor was going to ignore anyway.
+      for (const key of stray) delete target[key];
+      loggingHub?.error?.(
+        `[CLAIM-CREATOR] Stripped ${label} field(s) the attestor schema rejects: ${stray.join(", ")}`,
+        "claim.creation",
+      );
+    }
+
+    // Schema types paramValues as string→string. A customInjection can put a
+    // number or boolean here via window.Reclaim, which AJV rejects.
+    if (target.paramValues) {
+      for (const [key, value] of Object.entries(target.paramValues)) {
+        if (typeof value !== "string") {
+          loggingHub?.warn?.(
+            `[CLAIM-CREATOR] Coerced non-string ${label}.paramValues.${key} (${typeof value})`,
+            "claim.creation",
+          );
+          target.paramValues[key] = value === null || value === undefined ? "" : String(value);
+        }
+      }
+    }
+  }
+
+  // url, method and responseMatches are `required` in the schema.
+  const missing = ["url", "method", "responseMatches"].filter((key) => !params[key]);
+  if (missing.length) {
+    loggingHub?.error?.(
+      `[CLAIM-CREATOR] Claim params missing required field(s): ${missing.join(", ")}`,
+      "claim.creation",
+    );
+  }
+}

--- a/src/utils/claim-creator/claim-shape.test.js
+++ b/src/utils/claim-creator/claim-shape.test.js
@@ -1,0 +1,99 @@
+/**
+ * The attestor validates `params`/`secretParams` with AJV against schemas that
+ * are `additionalProperties: false`, server-side, at proof time. Anything extra
+ * fails the whole claim with a message that does not name the field — after the
+ * user has already logged in. These tests pin the local gate that prevents that.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import { assertClaimShape } from "./claim-shape.js";
+
+describe("assertClaimShape", () => {
+  const noopLogger = { error() {}, warn() {} };
+
+  it("strips params keys the attestor schema does not declare", () => {
+    // responseSelections is a real legacy provider field with no schema
+    // counterpart; it used to be copied straight into params.
+    const params = {
+      url: "https://x/y",
+      method: "GET",
+      responseMatches: [{ value: "a", type: "contains" }],
+      responseSelections: [{ value: "a" }],
+      order: 1,
+    };
+    assertClaimShape(params, {}, noopLogger);
+
+    assert.ok(!("responseSelections" in params));
+    assert.ok(!("order" in params));
+    assert.equal(params.url, "https://x/y");
+  });
+
+  it("keeps every key the schema does declare", () => {
+    const params = {
+      url: "https://x/y",
+      method: "POST",
+      geoLocation: "",
+      proxySessionId: "abcd1234",
+      headers: { Accept: "application/json" },
+      body: "{}",
+      writeRedactionMode: "zk",
+      additionalClientOptions: { supportedProtocolVersions: ["TLS1_3"] },
+      responseMatches: [{ value: "a", type: "contains" }],
+      responseRedactions: [{ jsonPath: "$.a" }],
+      paramValues: { a: "b" },
+    };
+    const before = Object.keys(params).length;
+    assertClaimShape(params, {}, noopLogger);
+    assert.equal(Object.keys(params).length, before);
+  });
+
+  it("strips secretParams keys outside its own schema", () => {
+    const secretParams = {
+      cookieStr: "a=b",
+      authorisationHeader: "Bearer x",
+      headers: { "X-Auth": "y" },
+      paramValues: { s: "1" },
+      // Not in HttpProviderSecretParameters.
+      body: "nope",
+    };
+    assertClaimShape({ url: "u", method: "GET", responseMatches: [] }, secretParams, noopLogger);
+    assert.ok(!("body" in secretParams));
+    assert.equal(secretParams.cookieStr, "a=b");
+  });
+
+  it("coerces non-string paramValues, which a customInjection can produce", () => {
+    // window.Reclaim lets a provider script hand back any JS value; the schema
+    // types paramValues as string→string.
+    const params = {
+      url: "u",
+      method: "GET",
+      responseMatches: [],
+      paramValues: { n: 42, b: true, nul: null, s: "ok" },
+    };
+    assertClaimShape(params, {}, noopLogger);
+    assert.deepEqual(params.paramValues, { n: "42", b: "true", nul: "", s: "ok" });
+  });
+
+  it("reports what it stripped rather than doing it silently", () => {
+    const errors = [];
+    const params = { url: "u", method: "GET", responseMatches: [], bogus: 1 };
+    assertClaimShape(params, {}, { error: (m) => errors.push(m), warn() {} });
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /bogus/);
+  });
+
+  it("reports missing required fields", () => {
+    const errors = [];
+    assertClaimShape({}, {}, { error: (m) => errors.push(m), warn() {} });
+    const message = errors.join("\n");
+    for (const required of ["url", "method", "responseMatches"]) {
+      assert.match(message, new RegExp(required));
+    }
+  });
+
+  it("tolerates a missing logger", () => {
+    assert.doesNotThrow(() => assertClaimShape({ bogus: 1 }, { bogus: 2 }, undefined));
+  });
+});

--- a/src/utils/claim-creator/example-provider.test.js
+++ b/src/utils/claim-creator/example-provider.test.js
@@ -1,0 +1,266 @@
+/**
+ * The `example` provider, end to end, from its real published definition.
+ *
+ * Every other test in this repo exercises one stage against a synthetic
+ * fixture. This one takes the three `requestData` entries of the PUBLISHED
+ * `example` provider (providerId `example`, version 3.0.0) and walks a real
+ * request/response pair through the whole client-side pipeline for each:
+ *
+ *     describeRequestMatch  ->  extractParamsFromResponse  ->  assertClaimShape
+ *
+ * The expected parameter values are the ones a real session actually produced
+ * (session 2b46b57c39), read back out of its logs — not values invented here.
+ * If any stage drifts, this fails with the provider that every developer uses
+ * as their first smoke test.
+ *
+ * WHAT THIS DOES NOT COVER: proof generation. That needs attestor-core's WASM,
+ * a live WebSocket to the attestor and the ZK circuits — none of which exist
+ * under `node --test`. So this proves the extension builds the right *claim*
+ * for all three requests; it does not prove the attestor accepts it. The
+ * attestor-side guarantee comes from attestor-parity.test.js (extraction
+ * matches the real attestor) and attestor-zk-engine.test.js (the pinned build
+ * can actually generate a proof).
+ *
+ * The provider walks three ORIGINS — example.org -> example.com ->
+ * jsonplaceholder — which is why it is also the case that broke the popup's
+ * claim counter; see claim-progress.test.js.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import { describeRequestMatch, MATCH_STAGES } from "./network-filter.js";
+import { extractParamsFromResponse } from "./params-extractor.js";
+
+/**
+ * The three requestData entries, verbatim from
+ * GET api.reclaimprotocol.org/api/providers/example (version 3.0.0).
+ * Trimmed only of fields the pipeline never reads (description, order,
+ * isOptional, credentials, expectedPageUrl, responseVariables).
+ */
+const REQUEST_DATA = [
+  {
+    url: "https://example.org/",
+    urlType: "TEMPLATE",
+    method: "GET",
+    responseMatches: [
+      { value: "{{pageTitle}}", type: "contains", invert: false },
+      { value: "<a href={{ianaLinkUrl}}>Learn more</a>", type: "contains", invert: false },
+    ],
+    responseRedactions: [
+      { xPath: "//title/text()", jsonPath: "", regex: "(.*)", hash: "" },
+      {
+        xPath: "/html/body/div[1]/p[2]/a",
+        jsonPath: "",
+        regex: "<a href=(.*)>Learn more</a>",
+        hash: null,
+      },
+    ],
+    bodySniff: { enabled: false, template: "" },
+    requestHash: "0xd29460cea971e27d1895d85c0ff9a1ecefbb1cf205586202f5394388255b7185",
+    writeRedactionMode: "zk",
+  },
+  {
+    url: "https://example.com/",
+    urlType: "TEMPLATE",
+    method: "GET",
+    responseMatches: [
+      { value: "{{pageTitle}}", type: "contains", invert: false },
+      { value: "<a href={{ianaLinkUrl}}>Learn more</a>", type: "contains", invert: false },
+    ],
+    responseRedactions: [
+      { xPath: "//title/text()", jsonPath: "", regex: "(.*)", hash: null },
+      {
+        xPath: "/html/body/div[1]/p[2]/a",
+        jsonPath: "",
+        regex: "<a href=(.*)>Learn more</a>",
+        hash: null,
+      },
+    ],
+    bodySniff: { enabled: false, template: "" },
+    requestHash: "0xcf312d890fd408a2aacb034afeb158a94d852960c1c1416054d468260b508e4f",
+    writeRedactionMode: "zk",
+  },
+  {
+    url: "https://jsonplaceholder.typicode.com/users/1",
+    urlType: "TEMPLATE",
+    method: "GET",
+    responseMatches: [
+      { value: "{{FullName}}", type: "contains", invert: false },
+      { value: "{{UserName}}", type: "contains", invert: false },
+      { value: "{{Email}}", type: "contains", invert: false },
+      { value: "{{id}}", type: "contains", invert: false },
+    ],
+    responseRedactions: [
+      { xPath: "", jsonPath: "$.name", regex: '"name": "(.*)"', hash: null },
+      { xPath: "", jsonPath: "$.username", regex: '"username": "(?<username>.*)"', hash: null },
+      // The one hashed redaction in the provider: its slice IS the value, and
+      // it must stay in params.paramValues rather than being forced secret.
+      { xPath: "", jsonPath: "$.email", regex: '"email": "(?<email>.*)"', hash: "oprf" },
+      { xPath: "", jsonPath: "$.id", regex: '"id": (.*)', hash: null },
+    ],
+    bodySniff: { enabled: false, template: "" },
+    requestHash: "0x64d5086d23eb500a178b49ec68efd780fff5664d54062add5b56daac334abe58",
+    writeRedactionMode: "zk",
+  },
+];
+
+/**
+ * The example.org / example.com body, shaped so the provider's XPaths resolve:
+ * `//title/text()` and `/html/body/div[1]/p[2]/a`.
+ */
+const EXAMPLE_HTML = `<!doctype html>
+<html>
+<head>
+    <title>Example Domain</title>
+    <meta charset="utf-8" />
+</head>
+<body>
+<div>
+    <h1>Example Domain</h1>
+    <p>This domain is for use in illustrative examples in documents.</p>
+    <p><a href="https://iana.org/domains/example">Learn more</a></p>
+</div>
+</body>
+</html>
+`;
+
+/**
+ * jsonplaceholder's /users/1 body. Two-space indented, which is what makes the
+ * provider's `"name": "(.*)"` regexes — note the space after the colon — match.
+ */
+const USER_JSON = `{
+  "id": 1,
+  "name": "Leanne Graham",
+  "username": "Bret",
+  "email": "Sincere@april.biz",
+  "address": {
+    "street": "Kulas Light",
+    "suite": "Apt. 556",
+    "city": "Gwenborough",
+    "zipcode": "92998-3874",
+    "geo": {
+      "lat": "-37.3159",
+      "lng": "81.1496"
+    }
+  },
+  "phone": "1-770-736-8031 x56442",
+  "website": "hildegard.org",
+  "company": {
+    "name": "Romaguera-Crona",
+    "catchPhrase": "Multi-layered client-server neural-net",
+    "bs": "harness real-time e-markets"
+  }
+}`;
+
+/** What the real session extracted, per requestData index. */
+const CASES = [
+  {
+    label: "example.org",
+    request: { url: "https://example.org/", method: "GET", responseText: EXAMPLE_HTML },
+    expected: {
+      pageTitle: "Example Domain",
+      ianaLinkUrl: '"https://iana.org/domains/example"',
+    },
+  },
+  {
+    label: "example.com",
+    request: { url: "https://example.com/", method: "GET", responseText: EXAMPLE_HTML },
+    expected: {
+      pageTitle: "Example Domain",
+      ianaLinkUrl: '"https://iana.org/domains/example"',
+    },
+  },
+  {
+    label: "jsonplaceholder /users/1",
+    request: {
+      url: "https://jsonplaceholder.typicode.com/users/1",
+      method: "GET",
+      responseText: USER_JSON,
+    },
+    expected: {
+      FullName: '"name": "Leanne Graham"',
+      UserName: '"username": "Bret"',
+      Email: "Sincere@april.biz",
+      id: '"id": 1',
+    },
+  },
+];
+
+describe("example provider: request matching", () => {
+  CASES.forEach((testCase, i) => {
+    it(`matches requestData[${i}] (${testCase.label})`, () => {
+      const verdict = describeRequestMatch(testCase.request, REQUEST_DATA[i], {});
+      assert.equal(
+        verdict.matched,
+        true,
+        `rejected at ${verdict.stage}: ${verdict.detail ?? "no detail"}`,
+      );
+      assert.equal(verdict.stage, MATCH_STAGES.MATCHED);
+    });
+  });
+
+  it("does not let one request satisfy another's matcher", () => {
+    // example.org and example.com differ only by TLD and are otherwise
+    // identical templates — a sloppy urlType change would collapse them, and
+    // the session would submit two proofs of the same page.
+    const verdict = describeRequestMatch(CASES[0].request, REQUEST_DATA[1], {});
+    assert.equal(verdict.matched, false);
+    assert.equal(verdict.stage, MATCH_STAGES.URL);
+  });
+
+  it("reports the stage when the response is not the expected one", () => {
+    const verdict = describeRequestMatch(
+      { ...CASES[2].request, responseText: '{"id": 2, "name": "Someone Else"}' },
+      REQUEST_DATA[2],
+      {},
+    );
+    // The provider's regexes need the pretty-printed spacing; a compact body
+    // fails the redaction pre-gate rather than silently producing no params.
+    assert.equal(verdict.matched, false);
+    assert.equal(verdict.stage, MATCH_STAGES.RESPONSE_REDACTION);
+    assert.match(verdict.detail, /redaction #\d/);
+  });
+});
+
+describe("example provider: parameter extraction", () => {
+  CASES.forEach((testCase, i) => {
+    it(`extracts requestData[${i}] (${testCase.label})`, () => {
+      const paramValues = extractParamsFromResponse(
+        testCase.request.responseText,
+        REQUEST_DATA[i].responseMatches,
+        REQUEST_DATA[i].responseRedactions,
+        {},
+      );
+      assert.deepEqual(paramValues, testCase.expected);
+    });
+  });
+
+  it("keeps the hashed (oprf) param as a plain extracted value", () => {
+    // The redaction on $.email carries hash: "oprf". Its slice is the value
+    // itself — there is no surrounding template to match against — and it must
+    // arrive unhashed here: privacy comes from the attestor's client-side OPRF
+    // substitution inside params, not from hiding it at extraction time.
+    const paramValues = extractParamsFromResponse(
+      USER_JSON,
+      REQUEST_DATA[2].responseMatches,
+      REQUEST_DATA[2].responseRedactions,
+      {},
+    );
+    assert.equal(paramValues.Email, "Sincere@april.biz");
+  });
+
+  it("covers all three of the provider's redaction styles", () => {
+    // Guards against a re-sync that quietly drops one branch of the
+    // xPath -> jsonPath -> regex chain: the provider uses xPath+regex,
+    // jsonPath+regex, and jsonPath+regex+hash across its three requests.
+    const styles = REQUEST_DATA.flatMap((rd) => rd.responseRedactions).map((r) =>
+      [r.xPath && "xPath", r.jsonPath && "jsonPath", r.regex && "regex", r.hash && "hash"]
+        .filter(Boolean)
+        .join("+"),
+    );
+    assert.ok(styles.includes("xPath+regex"), "xPath chain unused");
+    assert.ok(styles.includes("jsonPath+regex"), "jsonPath chain unused");
+    assert.ok(styles.includes("jsonPath+regex+hash"), "hashed chain unused");
+  });
+});

--- a/src/utils/claim-creator/make-regex.js
+++ b/src/utils/claim-creator/make-regex.js
@@ -1,0 +1,25 @@
+/**
+ * The attestor's regex constructor.
+ *
+ * Upstream (attestor-core src/providers/http/utils.ts) is `RE2(str, 'sgiu')`,
+ * but in a browser the attestor aliases `re2` to
+ * src/scripts/fallbacks/re2.ts — `new RegExp(pattern, flags.replace('u',''))` —
+ * so `sgi` is what the attestor actually evaluates provider regexes with in
+ * this environment. RE2 is not an option here regardless: webpack.config.js
+ * aliases `re2: false`.
+ *
+ * This lives in its own module, separate from ./vendor/attestor-http-utils.js,
+ * so the content script can share the attestor's regex flags without pulling
+ * xpath/parse5/esprima into a bundle that is injected at document_start on
+ * every page of every site.
+ *
+ * The flags matter: the previous code built flagless `new RegExp(pattern)`, so
+ * any provider regex relying on `s` (dot matches newline) or `i` behaved
+ * differently here than at the attestor.
+ *
+ * @param {string} str
+ * @returns {RegExp}
+ */
+export function makeRegex(str) {
+  return new RegExp(str, "sgi");
+}

--- a/src/utils/claim-creator/network-filter.js
+++ b/src/utils/claim-creator/network-filter.js
@@ -1,12 +1,10 @@
 // Import shared utility functions
-import {
-  getValueFromJsonPath,
-  getValueFromXPath,
-  isJsonFormat,
-  safeJsonParse,
-} from "./params-extractor-utils.js";
+import { isJsonFormat, jsonPathExists, safeJsonParse } from "./params-extractor-utils.js";
+import { makeRegex } from "./make-regex.js";
+// Dependency-free by design, so it is safe for the content bundle — see the
+// "Keep them out of the content bundle" rule for the vendored parsers.
+import { normalizeUrlType, URL_TYPES } from "../provider-normalization.js";
 
-// Escape special regex characters in string
 function escapeSpecialCharacters(input) {
   return input.replace(/[[\]()*+?.,\\^$|#]/g, "\\$&");
 }
@@ -34,7 +32,6 @@ function isJsonSubset(template, actual) {
   return Object.keys(template).every((key) => isJsonSubset(template[key], actual[key]));
 }
 
-// Extract template variables from a string
 function getTemplateVariables(template) {
   const paramRegex = /{{(\w+)}}/g;
   const variables = [];
@@ -47,12 +44,9 @@ function getTemplateVariables(template) {
   return variables;
 }
 
-// Convert template to regex, substituting known parameters
 export function convertTemplateToRegex(template, parameters = {}) {
-  // Escape special regex characters
   let escapedTemplate = escapeSpecialCharacters(template);
 
-  // Find all template variables
   const allVars = getTemplateVariables(template);
   const unsubstitutedVars = [];
 
@@ -77,191 +71,257 @@ export function convertTemplateToRegex(template, parameters = {}) {
   };
 }
 
-// Function to check if a request matches filtering criteria
-function matchesRequestCriteria(request, filterCriteria, parameters = {}) {
-  if (!filterCriteria || !request) return false;
+/**
+ * The gate's stages, in the order they are evaluated.
+ *
+ * A rejected request is otherwise indistinguishable from a request that was
+ * never made: everything that logs about extraction runs only *after* a match,
+ * so a provider whose bodySniff template is stale fails on the session timer
+ * looking exactly like "the user never logged in". Naming the stage a candidate
+ * died at is the only signal that separates the two.
+ *
+ * Order matters — callers compare `MATCH_STAGE_ORDER.indexOf(stage)` to track
+ * the furthest point any request reached against a given matcher.
+ */
+export const MATCH_STAGES = {
+  URL: "url",
+  METHOD: "method",
+  BODY: "body",
+  RESPONSE_MISSING: "responseMissing",
+  RESPONSE_MATCH: "responseMatch",
+  RESPONSE_REDACTION: "responseRedaction",
+  MATCHED: "matched",
+};
+
+export const MATCH_STAGE_ORDER = [
+  MATCH_STAGES.URL,
+  MATCH_STAGES.METHOD,
+  MATCH_STAGES.BODY,
+  MATCH_STAGES.RESPONSE_MISSING,
+  MATCH_STAGES.RESPONSE_MATCH,
+  MATCH_STAGES.RESPONSE_REDACTION,
+  MATCH_STAGES.MATCHED,
+];
+
+const matched = () => ({ matched: true, stage: MATCH_STAGES.MATCHED });
+const rejected = (stage, detail) => ({ matched: false, stage, detail });
+
+function describeRequestCriteria(request, filterCriteria, parameters = {}) {
+  if (!filterCriteria || !request) {
+    return rejected(MATCH_STAGES.URL, "no request or no criteria");
+  }
 
   // 1) URL match: exact, REGEX, or TEMPLATE
-  const urlMatches = (() => {
-    const { url, urlType } = filterCriteria;
-    if (!url) return false;
+  const { url, urlType } = filterCriteria;
+  if (!url) return rejected(MATCH_STAGES.URL, "criteria carries no url");
 
-    const type = (urlType || "EXACT").toUpperCase();
+  // CONSTANT is upstream's default and its name for a plain URL; EXACT is this
+  // SDK's local alias for the same thing. An unknown value is inferred from the
+  // url rather than left unmatchable — this branch used to `return false` for
+  // everything it did not recognise, so a provider carrying the canonical
+  // CONSTANT never matched a single request.
+  const type = normalizeUrlType(urlType, url);
 
-    if (type === "EXACT") {
-      return url === request.url;
-    }
+  const urlMatches =
+    type === URL_TYPES.CONSTANT
+      ? url === request.url
+      : makeRegex(convertTemplateToRegex(url, parameters).pattern).test(request.url);
 
-    if (type === "REGEX" || type === "TEMPLATE") {
-      const { pattern } = convertTemplateToRegex(url, parameters);
+  if (!urlMatches) return rejected(MATCH_STAGES.URL, `${type} url did not match`);
 
-      return new RegExp(pattern).test(request.url);
-    }
-
-    return false;
-  })();
-
-  if (!urlMatches) return false;
   if (request.method?.toUpperCase() !== filterCriteria.method?.toUpperCase()) {
-    return false;
+    return rejected(
+      MATCH_STAGES.METHOD,
+      `expected ${filterCriteria.method}, saw ${request.method}`,
+    );
   }
 
   // 3) Body match (only if enabled)
-  const bodyMatches = (() => {
-    const sniff = filterCriteria.bodySniff;
-    if (!sniff || !sniff.enabled) return true;
-    const bodyTemplate = sniff.template ?? "";
-    const requestBody =
-      typeof request.body === "string" ? request.body : JSON.stringify(request.body ?? {});
+  const sniff = filterCriteria.bodySniff;
+  if (!sniff || !sniff.enabled) return matched();
 
-    // exact body equality satisfies body criterion
-    if (bodyTemplate === requestBody) return true;
+  const bodyTemplate = sniff.template ?? "";
+  const requestBody =
+    typeof request.body === "string" ? request.body : JSON.stringify(request.body ?? {});
 
-    // A literal (var-free) JSON template only needs to be a structural subset
-    // of the real body — a strict string/regex match breaks the moment the
-    // site appends a new field to the payload.
-    if (
-      getTemplateVariables(bodyTemplate).length === 0 &&
-      isJsonFormat(bodyTemplate) &&
-      isJsonFormat(requestBody)
-    ) {
-      const templateJson = safeJsonParse(bodyTemplate);
-      const requestJson = safeJsonParse(requestBody);
-      if (templateJson && requestJson && isJsonSubset(templateJson, requestJson)) {
-        return true;
-      }
+  // exact body equality satisfies body criterion
+  if (bodyTemplate === requestBody) return matched();
+
+  // A literal (var-free) JSON template only needs to be a structural subset
+  // of the real body — a strict string/regex match breaks the moment the
+  // site appends a new field to the payload.
+  if (
+    getTemplateVariables(bodyTemplate).length === 0 &&
+    isJsonFormat(bodyTemplate) &&
+    isJsonFormat(requestBody)
+  ) {
+    const templateJson = safeJsonParse(bodyTemplate);
+    const requestJson = safeJsonParse(requestBody);
+    if (templateJson && requestJson && isJsonSubset(templateJson, requestJson)) {
+      return matched();
     }
-
-    // template/regex body match
-    const { pattern } = convertTemplateToRegex(bodyTemplate, parameters);
-    return new RegExp(pattern).test(requestBody);
-  })();
-
-  return bodyMatches;
-}
-
-// Function to check if response matches criteria
-function matchesResponseCriteria(responseText, matchCriteria, parameters = {}) {
-  if (!matchCriteria || matchCriteria.length === 0) {
-    return true;
   }
 
-  for (const match of matchCriteria) {
+  const { pattern } = convertTemplateToRegex(bodyTemplate, parameters);
+  if (makeRegex(pattern).test(requestBody)) return matched();
+
+  // The actual body is the user's request payload, so only its size travels in
+  // the message. The template is provider-authored and is the thing worth
+  // reading, but it can be long — callers pass it through the log payload.
+  return rejected(
+    MATCH_STAGES.BODY,
+    `bodySniff template (${bodyTemplate.length} chars) did not match the request body (${requestBody.length} chars)`,
+  );
+}
+
+function describeResponseCriteria(responseText, matchCriteria, parameters = {}) {
+  if (!matchCriteria || matchCriteria.length === 0) {
+    return matched();
+  }
+
+  for (let i = 0; i < matchCriteria.length; i++) {
+    const match = matchCriteria[i];
     let pattern;
     if (match.type === "regex") {
       pattern = match.value;
     } else {
       pattern = convertTemplateToRegex(match.value, parameters).pattern;
     }
-    const regex = new RegExp(pattern);
+    const regex = makeRegex(pattern);
     const matches = regex.test(responseText);
-    // Check if match expectation is met
     const matchExpectation = match.invert ? !matches : matches;
     if (!matchExpectation) {
-      return false;
+      // `match.value` is provider-authored (a template with {{param}}
+      // placeholders), so it is safe in the message; the response is not, and
+      // only its size appears.
+      return rejected(
+        MATCH_STAGES.RESPONSE_MATCH,
+        `responseMatch #${i} ${match.invert ? "(inverted) " : ""}"${match.value}" not satisfied by the response (${responseText.length} chars)`,
+      );
     }
   }
 
-  return true;
+  return matched();
 }
 
-// Function to check if response fields match responseRedactions criteria
-function matchesResponseFields(responseText, responseRedactions, logger) {
+// Cheap pre-gate over responseRedactions.
+//
+// This is only a presence check — it produces no values. Authoritative
+// resolution (the attestor's xPath -> jsonPath -> regex chain) runs in the
+// background via ../claim-creator/attestor-extraction.js, which is where the
+// parsers live.
+//
+// Notably there is no xPath branch. There used to be, backed by a
+// regex-on-tag-name stand-in that could not evaluate most real XPath
+// expressions, so it rejected pages the attestor would have accepted. A
+// faithful xPath check needs xpath+parse5, and this module is bundled into a
+// content script injected at document_start on every page of every site — so
+// xPath is deferred to the background rather than approximated here.
+function describeResponseFields(responseText, responseRedactions, logger) {
   if (!responseRedactions || responseRedactions.length === 0) {
-    return true;
+    return matched();
   }
 
-  // Try to parse JSON if the response appears to be JSON
-  let jsonData = null;
-  const isJson = isJsonFormat(responseText);
+  const reject = (detail) => rejected(MATCH_STAGES.RESPONSE_REDACTION, detail);
 
-  if (isJson) {
-    jsonData = safeJsonParse(responseText);
-  }
+  for (let i = 0; i < responseRedactions.length; i++) {
+    const redaction = responseRedactions[i];
+    // An xPath-only redaction can't be pre-checked cheaply; let the background
+    // decide rather than guess.
+    if (redaction.xPath && !redaction.jsonPath && !redaction.regex) {
+      continue;
+    }
 
-  // Check each redaction pattern
-  for (const redaction of responseRedactions) {
-    // If jsonPath is specified and response is JSON
-    if (redaction.jsonPath && jsonData) {
-      try {
-        const value = getValueFromJsonPath(jsonData, redaction.jsonPath);
-        // If we get here but value is undefined, the path doesn't exist
-        if (value === undefined) return false;
-      } catch (error) {
-        logger.error(
-          `[NETWORK-FILTER] Error checking jsonPath ${redaction.jsonPath}: ${error?.message}`,
-          "content.filter",
+    // jsonPath is only meaningful once an xPath has narrowed to a JSON island;
+    // when there's an xPath in play, defer the whole redaction.
+    if (redaction.jsonPath && !redaction.xPath) {
+      if (!isJsonFormat(responseText)) {
+        return reject(
+          `redaction #${i} needs jsonPath ${redaction.jsonPath} but the response is not JSON (${responseText.length} chars)`,
         );
-        return false;
       }
-    }
-    // If xPath is specified and response is not JSON (assumed to be HTML)
-    else if (redaction.xPath && !isJson) {
-      try {
-        const value = getValueFromXPath(responseText, redaction.xPath);
-        if (!value) return false;
-      } catch (error) {
-        logger.error(
-          `[NETWORK-FILTER] Error checking xPath ${redaction.xPath}: ${error?.message}`,
-          "content.filter",
-        );
-        return false;
+      if (!jsonPathExists(responseText, redaction.jsonPath)) {
+        return reject(`redaction #${i} jsonPath ${redaction.jsonPath} is absent from the response`);
       }
+      continue;
     }
-    // If regex is specified
-    else if (redaction.regex) {
+
+    // A regex nested under an xPath applies to the selected element, not the
+    // whole body, so it can't be tested here either.
+    if (redaction.regex && !redaction.xPath) {
       try {
-        const regex = new RegExp(redaction.regex);
-        if (!regex.test(responseText)) return false;
+        if (!makeRegex(redaction.regex).test(responseText)) {
+          return reject(`redaction #${i} regex ${redaction.regex} did not match the response`);
+        }
       } catch (error) {
-        logger.error(
+        logger?.error?.(
           `[NETWORK-FILTER] Error checking regex ${redaction.regex}: ${error?.message}`,
           "content.filter",
         );
-        return false;
+        return reject(`redaction #${i} regex ${redaction.regex} is invalid: ${error?.message}`);
       }
     }
   }
 
   // All checks passed
-  return true;
+  return matched();
 }
 
-// Main filtering function
-export const filterRequest = (request, filterCriteria, parameters = {}, logger) => {
+/**
+ * The gate, with a reason attached.
+ *
+ * @returns {{matched: boolean, stage: string, detail?: string}} `stage` is the
+ *  point evaluation stopped — `MATCH_STAGES.MATCHED` on success, otherwise the
+ *  check that rejected the request. `detail` never carries response or request
+ *  bodies, only provider-authored patterns and sizes: it becomes a log line,
+ *  and log lines are not redacted.
+ */
+export const describeRequestMatch = (request, filterCriteria, parameters = {}, logger) => {
   try {
     // First check if request matches criteria
-    if (!matchesRequestCriteria(request, filterCriteria, parameters)) {
-      return false;
-    }
+    const requestVerdict = describeRequestCriteria(request, filterCriteria, parameters);
+    if (!requestVerdict.matched) return requestVerdict;
 
     // If criteria requires response validation but we have no response, reject
+    const needsResponse =
+      filterCriteria.responseMatches?.length > 0 || filterCriteria.responseRedactions?.length > 0;
+    if (needsResponse && !request.responseText) {
+      // Routine rather than fatal: the content script pairs a request with its
+      // response asynchronously, so this is the normal state on the tick
+      // between the two.
+      return rejected(MATCH_STAGES.RESPONSE_MISSING, "no response body paired with this request");
+    }
+
     if (filterCriteria.responseMatches && filterCriteria.responseMatches.length > 0) {
-      if (!request.responseText) {
-        return false;
-      }
-      if (
-        !matchesResponseCriteria(request.responseText, filterCriteria.responseMatches, parameters)
-      ) {
-        return false;
-      }
+      const responseVerdict = describeResponseCriteria(
+        request.responseText,
+        filterCriteria.responseMatches,
+        parameters,
+      );
+      if (!responseVerdict.matched) return responseVerdict;
     }
 
-    // Check if the response fields match the responseRedactions criteria
     if (filterCriteria.responseRedactions && filterCriteria.responseRedactions.length > 0) {
-      if (!request.responseText) {
-        return false;
-      }
-      if (!matchesResponseFields(request.responseText, filterCriteria.responseRedactions, logger)) {
-        return false;
-      }
+      const fieldsVerdict = describeResponseFields(
+        request.responseText,
+        filterCriteria.responseRedactions,
+        logger,
+      );
+      if (!fieldsVerdict.matched) return fieldsVerdict;
     }
 
-    return true;
+    return matched();
   } catch (error) {
-    logger.error("[NETWORK-FILTER] Error filtering request: " + error?.message, "content.filter");
-    return false;
+    logger?.error?.(
+      "[NETWORK-FILTER] Error filtering request: " + error?.message,
+      "content.filter",
+    );
+    return rejected(MATCH_STAGES.URL, `threw: ${error?.message}`);
   }
 };
+
+// Main filtering function
+export const filterRequest = (request, filterCriteria, parameters = {}, logger) =>
+  describeRequestMatch(request, filterCriteria, parameters, logger).matched;
 
 //tryWithNonce/tryWithTT/tryPlain

--- a/src/utils/claim-creator/network-filter.test.js
+++ b/src/utils/claim-creator/network-filter.test.js
@@ -1,0 +1,217 @@
+/**
+ * The URL half of the content-script gate.
+ *
+ * This gate decides whether a request is ever forwarded to the background, so a
+ * miss here is not a degraded claim — it is no claim at all. Nothing downstream
+ * logs, because nothing downstream runs: the session simply dies on the timer
+ * with "request intercepted" as its last word. That happened for real with a
+ * provider whose `urlType` was the upstream default, `CONSTANT`, which this gate
+ * did not recognise and therefore never matched.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import { filterRequest, describeRequestMatch, MATCH_STAGES } from "./network-filter.js";
+
+const RESPONSE = '{"user":{"name":"sajjad"}}';
+
+/** Minimal shape filterRequest expects for a GET whose response we don't gate on. */
+function request(url, overrides = {}) {
+  return { url, method: "GET", responseText: RESPONSE, ...overrides };
+}
+
+function criteria(overrides = {}) {
+  return {
+    url: "https://etherscan.io/myaccount",
+    method: "GET",
+    responseMatches: [],
+    responseRedactions: [],
+    ...overrides,
+  };
+}
+
+describe("url matching by urlType", () => {
+  it("matches the upstream default, CONSTANT", () => {
+    // Regression guard. The upstream enum is REGEX | CONSTANT | TEMPLATE, and
+    // InApp infers CONSTANT for any url without "{{" — so this is the value most
+    // providers carry. The gate used to fall through to `return false`.
+    assert.equal(
+      filterRequest(request("https://etherscan.io/myaccount"), criteria({ urlType: "CONSTANT" })),
+      true,
+    );
+  });
+
+  it("still honours EXACT, this SDK's local alias", () => {
+    // Not in the upstream enum, but the background writes it on synthetic
+    // requests and it has always meant equality here.
+    assert.equal(
+      filterRequest(request("https://etherscan.io/myaccount"), criteria({ urlType: "EXACT" })),
+      true,
+    );
+  });
+
+  it("does not match a different url under CONSTANT", () => {
+    assert.equal(
+      filterRequest(
+        request("https://etherscan.io/somewhere-else"),
+        criteria({ urlType: "CONSTANT" }),
+      ),
+      false,
+    );
+  });
+
+  it("expands placeholders under TEMPLATE", () => {
+    assert.equal(
+      filterRequest(
+        request("https://etherscan.io/users/12345/profile"),
+        criteria({ url: "https://etherscan.io/users/{{userId}}/profile", urlType: "TEMPLATE" }),
+      ),
+      true,
+    );
+  });
+
+  it("infers rather than refusing when urlType is absent or unknown", () => {
+    // Guessing wrong costs one non-matching request; refusing to match costs the
+    // entire verification. So an unknown value is inferred from the url.
+    for (const urlType of [undefined, null, "", "SOMETHING_NEW"]) {
+      assert.equal(
+        filterRequest(request("https://etherscan.io/myaccount"), criteria({ urlType })),
+        true,
+        `plain url with urlType=${JSON.stringify(urlType)}`,
+      );
+      assert.equal(
+        filterRequest(
+          request("https://etherscan.io/users/12345/profile"),
+          criteria({ url: "https://etherscan.io/users/{{userId}}/profile", urlType }),
+        ),
+        true,
+        `templated url with urlType=${JSON.stringify(urlType)}`,
+      );
+    }
+  });
+
+  it("still requires the method to agree", () => {
+    assert.equal(
+      filterRequest(
+        request("https://etherscan.io/myaccount", { method: "POST" }),
+        criteria({ urlType: "CONSTANT" }),
+      ),
+      false,
+    );
+  });
+});
+
+describe("why a request was rejected", () => {
+  // A rejected candidate is otherwise completely silent: everything that logs
+  // about extraction runs only after a match, so a stale bodySniff template and
+  // "the user never logged in" produce identical sessions. The stage is the
+  // only thing that separates them.
+
+  it("names the check that stopped it", () => {
+    const cases = [
+      [
+        "url",
+        request("https://etherscan.io/somewhere-else"),
+        criteria({ urlType: "CONSTANT" }),
+        MATCH_STAGES.URL,
+      ],
+      [
+        "method",
+        request("https://etherscan.io/myaccount", { method: "POST" }),
+        criteria({ urlType: "CONSTANT" }),
+        MATCH_STAGES.METHOD,
+      ],
+      [
+        "body",
+        request("https://etherscan.io/myaccount", { method: "POST", body: '{"page":2}' }),
+        criteria({
+          method: "POST",
+          urlType: "CONSTANT",
+          bodySniff: { enabled: true, template: '{"page":1}' },
+        }),
+        MATCH_STAGES.BODY,
+      ],
+      [
+        "responseMissing",
+        request("https://etherscan.io/myaccount", { responseText: "" }),
+        criteria({ urlType: "CONSTANT", responseMatches: [{ value: "sajjad", type: "contains" }] }),
+        MATCH_STAGES.RESPONSE_MISSING,
+      ],
+      [
+        "responseMatch",
+        request("https://etherscan.io/myaccount"),
+        criteria({ urlType: "CONSTANT", responseMatches: [{ value: "nobody", type: "contains" }] }),
+        MATCH_STAGES.RESPONSE_MATCH,
+      ],
+      [
+        "responseRedaction",
+        request("https://etherscan.io/myaccount"),
+        criteria({ urlType: "CONSTANT", responseRedactions: [{ jsonPath: "$.user.missing" }] }),
+        MATCH_STAGES.RESPONSE_REDACTION,
+      ],
+    ];
+
+    for (const [label, req, crit, expected] of cases) {
+      const verdict = describeRequestMatch(req, crit, {});
+      assert.equal(verdict.matched, false, `${label} should not match`);
+      assert.equal(verdict.stage, expected, `${label} stage`);
+      assert.ok(verdict.detail, `${label} must carry a reason`);
+    }
+  });
+
+  it("reports MATCHED when everything passes", () => {
+    const verdict = describeRequestMatch(
+      request("https://etherscan.io/myaccount"),
+      criteria({ urlType: "CONSTANT", responseMatches: [{ value: "sajjad", type: "contains" }] }),
+      {},
+    );
+    assert.deepEqual(verdict, { matched: true, stage: MATCH_STAGES.MATCHED });
+  });
+
+  it("keeps request and response bodies out of the reason", () => {
+    // `detail` becomes a log line, and log lines are never redacted — only the
+    // structured payload is. A body echoed here would reach Loki verbatim on
+    // every near miss, which is exactly how RedactionResolveError once leaked
+    // the user's authenticated page.
+    const secretBody = '{"accountNumber":"1234567890"}';
+    const secretResponse = '{"user":{"name":"topsecretuser"}}';
+
+    const bodyVerdict = describeRequestMatch(
+      request("https://etherscan.io/myaccount", { method: "POST", body: secretBody }),
+      criteria({
+        method: "POST",
+        urlType: "CONSTANT",
+        bodySniff: { enabled: true, template: '{"page":1}' },
+      }),
+      {},
+    );
+    assert.ok(!bodyVerdict.detail.includes("1234567890"), "request body leaked into the reason");
+    assert.ok(bodyVerdict.detail.includes("chars"), "sizes are the substitute");
+
+    const responseVerdict = describeRequestMatch(
+      request("https://etherscan.io/myaccount", { responseText: secretResponse }),
+      criteria({ urlType: "CONSTANT", responseMatches: [{ value: "nobody", type: "contains" }] }),
+      {},
+    );
+    assert.ok(
+      !responseVerdict.detail.includes("topsecretuser"),
+      "response body leaked into the reason",
+    );
+    // The provider-authored pattern is what makes the line actionable, and is
+    // config rather than user data.
+    assert.ok(responseVerdict.detail.includes("nobody"));
+  });
+
+  it("does not treat a missing response as fatal when nothing gates on it", () => {
+    // Regression guard: `needsResponse` has to stay equivalent to the two
+    // separate `if (!responseText) return false` checks it replaced, or every
+    // request with no response body would stop matching.
+    const verdict = describeRequestMatch(
+      request("https://etherscan.io/myaccount", { responseText: "" }),
+      criteria({ urlType: "CONSTANT" }),
+      {},
+    );
+    assert.equal(verdict.matched, true);
+  });
+});

--- a/src/utils/claim-creator/params-extractor-utils.js
+++ b/src/utils/claim-creator/params-extractor-utils.js
@@ -1,62 +1,43 @@
 /**
- * Utility functions for extracting values from JSON and HTML responses
- * Shared between network-filter.js and params-extractor.js
+ * Shared JSON helpers for the content-script request filter.
+ *
+ * The xPath/jsonPath value extractors that used to live here are gone: they
+ * diverged from the attestor (a regex-on-tag-name "XPath", and a JSONPath that
+ * returned a re-serialized JS value rather than the raw response slice), which
+ * meant a provider path that worked in the attestor and the InApp SDK could
+ * silently fail here. Authoritative extraction now lives in
+ * ./attestor-extraction.js on top of the vendored attestor code.
  */
 
 import { JSONPath } from "jsonpath-plus";
 
 /**
- * Extract values from JSON response using jsonPath
- * @param {Object} jsonData - Parsed JSON response
- * @param {string} jsonPath - JSONPath expression (e.g., $.userName, $.profile.electronicAddresses[0].email)
- * @returns {any} Extracted value or null if not found
+ * Does this jsonPath resolve against this response body?
+ *
+ * Uses the same JSONPath options as the attestor's `extractJSONValueIndexes`
+ * (wrap/resultType/eval/ignoreEvalErrors), so the content-script gate agrees
+ * with the attestor about whether a path exists. It deliberately stops at
+ * "does a pointer come back" — turning the pointer into a byte range needs
+ * esprima, and that only happens in the background, where the authoritative
+ * extraction runs.
+ *
+ * @param {string} responseText - raw response body
+ * @returns {boolean}
  */
-export const getValueFromJsonPath = (jsonData, jsonPath) => {
+export const jsonPathExists = (responseText, jsonPath) => {
   try {
-    const results = JSONPath({ path: jsonPath, json: jsonData });
-    const finalResult = results?.[0];
-    if (finalResult === undefined) {
-      return undefined;
-    } else if (finalResult === null) {
-      return "null";
-    }
-    return finalResult;
-  } catch (error) {
-    console.error(
-      `[PARAMS-EXTRACTOR-UTILS] Error extracting JSON value with path ${jsonPath}:`,
-      error,
-    );
-    return undefined;
-  }
-};
-
-/**
- * Extract values from HTML response using XPath (simplified)
- * @param {string} htmlString - HTML string
- * @param {string} xPath - XPath expression
- * @returns {string|null|undefined} Extracted value or null if not found
- */
-export const getValueFromXPath = (htmlString, xPath) => {
-  // This is a simplified implementation
-  // For proper XPath parsing, a library would be needed
-  try {
-    // Extract with regex based on the xPath pattern
-    // This is a very basic implementation and won't work for all XPath expressions
-    const cleanedXPath = xPath.replace(/^\/\//, "").replace(/\/@/, " ");
-    const parts = cleanedXPath.split("/");
-    const element = parts[parts.length - 1];
-
-    // Simple regex to find elements with content
-    const regex = new RegExp(`<${element}[^>]*>(.*?)<\/${element}>`, "i");
-    const match = htmlString.match(regex);
-
-    return match ? match[1] : undefined;
-  } catch (error) {
-    console.error(
-      `[PARAMS-EXTRACTOR-UTILS] Error extracting HTML value with XPath ${xPath}:`,
-      error,
-    );
-    return undefined;
+    const pointers = JSONPath({
+      path: jsonPath,
+      json: JSON.parse(responseText),
+      wrap: false,
+      resultType: "pointer",
+      eval: "safe",
+      ignoreEvalErrors: true,
+    });
+    if (!pointers) return false;
+    return Array.isArray(pointers) ? pointers.length > 0 : true;
+  } catch {
+    return false;
   }
 };
 

--- a/src/utils/claim-creator/params-extractor.js
+++ b/src/utils/claim-creator/params-extractor.js
@@ -1,11 +1,14 @@
 // Utility functions for parameter extraction from various sources
-import { convertTemplateToRegex } from "./network-filter";
+import { convertTemplateToRegex } from "./network-filter.js";
 import {
-  getValueFromJsonPath,
-  getValueFromXPath,
-  isJsonFormat,
-  safeJsonParse,
-} from "./params-extractor-utils.js";
+  makeRegex,
+  resolveRedaction,
+  describeRedaction,
+  RedactionResolveError,
+} from "./attestor-extraction.js";
+// .js extension required: Node's ESM loader does not resolve extensionless
+// relative paths, and this module is unit-tested (see CLAUDE.md).
+import { EVENT_TYPES } from "../logger/constants.js";
 
 /**
  * Extract dynamic parameters from a string by matching {{PARAM_NAME}} patterns
@@ -19,6 +22,19 @@ export const extractDynamicParamNames = (text) => {
 };
 
 /**
+ * `convertTemplateToRegex` substitutes each placeholder with a lazy `(.*?)`,
+ * which is right for a boolean match but wrong for extraction: a placeholder at
+ * the very end of a template has nothing after it to force the lazy group to
+ * expand, so it captures the empty string. Anchoring with `$` in that case (and
+ * only that case) makes the final group consume the remainder.
+ *
+ * Templates that don't end in a placeholder are left untouched, so a URL
+ * carrying extra query params the template doesn't describe still matches.
+ */
+const anchorTrailingPlaceholder = (template, pattern) =>
+  template.trimEnd().endsWith("}}") ? `${pattern}$` : pattern;
+
+/**
  * Extract parameter values from URL using template matching
  * @param {string} urlTemplate - URL template with {{param}} placeholders
  * @param {string} actualUrl - Actual URL with values
@@ -28,12 +44,16 @@ export const extractDynamicParamNames = (text) => {
 export const extractParamsFromUrl = (urlTemplate, actualUrl, paramValues = {}) => {
   if (!urlTemplate || !actualUrl) return paramValues;
 
-  // Extract param names from template
   const paramNames = extractDynamicParamNames(urlTemplate);
-  const regex = convertTemplateToRegex(urlTemplate, paramNames).pattern;
+  const pattern = anchorTrailingPlaceholder(
+    urlTemplate,
+    convertTemplateToRegex(urlTemplate, paramNames).pattern,
+  );
 
-  // Match actual URL against the pattern
-  const match = actualUrl.match(regex);
+  // Match actual URL against the pattern. `.exec` rather than
+  // `String.match`: makeRegex sets the `g` flag (to mirror the attestor's
+  // flags) and `String.match` with `g` returns full matches, not groups.
+  const match = makeRegex(pattern).exec(actualUrl);
   if (match && match.length > 1) {
     // Start from index 1 to skip the full match
     for (let i = 0; i < paramNames.length; i++) {
@@ -55,14 +75,15 @@ export const extractParamsFromUrl = (urlTemplate, actualUrl, paramValues = {}) =
 export const extractParamsFromBody = (bodyTemplate, actualBody, paramValues = {}) => {
   if (!bodyTemplate || !actualBody) return paramValues;
 
-  // Extract param names from template
   const paramNames = extractDynamicParamNames(bodyTemplate);
 
-  const { pattern } = convertTemplateToRegex(bodyTemplate, {});
-  const regex = new RegExp(pattern);
+  const pattern = anchorTrailingPlaceholder(
+    bodyTemplate,
+    convertTemplateToRegex(bodyTemplate, {}).pattern,
+  );
 
-  // Match actual body against the pattern
-  const match = actualBody.match(regex);
+  // `.exec` rather than `String.match` — see extractParamsFromUrl.
+  const match = makeRegex(pattern).exec(actualBody);
   if (match && match.length > 1) {
     // Start from index 1 to skip the full match
     for (let i = 0; i < paramNames.length; i++) {
@@ -75,97 +96,251 @@ export const extractParamsFromBody = (bodyTemplate, actualBody, paramValues = {}
   return paramValues;
 };
 
+// Regex specials to escape in a `contains` template. Braces are deliberately
+// excluded so `{{param}}` placeholders survive escaping and can be substituted
+// afterwards.
+const REGEX_SPECIALS = /[.*+?^$()|[\]\\]/g;
+
+// A named capture group must be a valid JS identifier.
+const VALID_GROUP_NAME = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+const escapeRegexLiterals = (input) => input.replace(REGEX_SPECIALS, "\\$&");
+
 /**
- * Extract parameter values from response text using responseMatches and responseRedactions
+ * Turn a responseMatch value into a regex with one capture group per
+ * `{{param}}` placeholder. This is `substituteParamValues` (attestor-core
+ * src/providers/http/index.ts) run backwards: whatever this pulls out is what
+ * the attestor will substitute back in and re-assert against the response, so
+ * the value has to come from the raw response bytes, unmodified.
+ *
+ * Named groups are used when every param name is a valid JS identifier, which
+ * keeps the mapping obvious. Names that aren't (`{{user-id}}`, `{{2fa}}`) fall
+ * back to positional groups mapped by placeholder order — a named group with
+ * such a name is a regex syntax error, and dropping those params would be a
+ * regression.
+ *
+ * @param {string} matchValue
+ * @param {string} type - "regex" leaves the value as a regex; anything else
+ *  ("contains", the default) treats it as a literal.
+ * @param {string[]} paramNames
+ * @returns {{regex: RegExp, named: boolean}|null}
+ */
+const buildTemplateRegex = (matchValue, type, paramNames) => {
+  const named = paramNames.every((name) => VALID_GROUP_NAME.test(name));
+
+  let pattern = type === "regex" ? matchValue : escapeRegexLiterals(matchValue);
+
+  for (const name of paramNames) {
+    const placeholder = `{{${name}}}`;
+    let seen = false;
+    while (pattern.includes(placeholder)) {
+      // First occurrence captures; a repeat becomes a backreference, since a
+      // duplicated group name is a syntax error. Positional mode can't express
+      // a backreference by name, so a repeat just captures again — harmless,
+      // because the values are read back by placeholder order.
+      const replacement = named ? (seen ? `\\k<${name}>` : `(?<${name}>.*?)`) : "(.*?)";
+      pattern = pattern.replace(placeholder, replacement);
+      seen = true;
+    }
+  }
+
+  try {
+    return { regex: makeRegex(pattern), named };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Extract parameter values from response text using responseMatches and
+ * responseRedactions.
+ *
+ * Resolution follows the attestor's chain (xPath -> jsonPath -> regex, see
+ * ./attestor-extraction.js) and the value is taken from the raw response slice,
+ * never from a re-serialized JS value — a re-serialized object differs from the
+ * response bytes in key order, spacing and escaping, and the attestor then
+ * rejects the claim.
+ *
  * @param {string} responseText - Response body text
  * @param {Array} responseMatches - Array of response match objects
  * @param {Array} responseRedactions - Array of response redaction objects
- * @param {Object} paramValues - Object to store extracted parameter values
+ * @param {Object} paramValues - Object to store extracted parameter values.
+ *  Params already present here are treated as satisfied, so a redaction that
+ *  can't resolve for an already-known param (e.g. supplied by a custom
+ *  injection) is not fatal.
+ * @param {Object} [logger] - optional logger
  * @returns {Object} Updated paramValues object
+ * @throws {RedactionResolveError} if a redaction for an unknown param does not
+ *  resolve against this response — the caller should keep looking rather than
+ *  fail the session.
  */
 export const extractParamsFromResponse = (
   responseText,
   responseMatches,
   responseRedactions,
   paramValues = {},
+  logger,
 ) => {
-  if (!responseText) return paramValues;
+  if (!responseText || !responseMatches?.length) return paramValues;
 
-  try {
-    // First, determine if the response is JSON or HTML
-    let jsonData = null;
-    const isJson = isJsonFormat(responseText);
+  logger?.info?.(
+    `[PARAM-EXTRACTOR] Validating ${responseMatches.length} response match(es)`,
+    "claim.params",
+    { eventType: EVENT_TYPES.VALIDATING_CLAIM_PARAMETERS },
+  );
 
-    if (isJson) {
-      jsonData = safeJsonParse(responseText);
-    }
+  for (let i = 0; i < responseMatches.length; i++) {
+    const match = responseMatches[i];
+    if (!match?.value) continue;
 
-    // Process responseMatches to extract parameters
-    if (
-      responseMatches &&
-      responseMatches.length > 0 &&
-      responseRedactions &&
-      responseRedactions.length > 0
-    ) {
-      // iterate over the responseMatches and responseRedactions both have elements with co related to the same index
-      for (let i = 0; i < responseMatches.length; i++) {
-        const match = responseMatches[i];
-        const redaction = responseRedactions[i];
+    const paramNames = extractDynamicParamNames(match.value);
+    if (paramNames.length === 0) continue;
 
-        if (!match.value) continue;
+    // Params already known (custom injection, URL/body template) don't need to
+    // be re-derived, and must not make an unresolvable redaction fatal.
+    const alreadyKnown = paramNames.every((name) => paramValues[name] !== undefined);
 
-        // Extract param names from match value expect one parameter per responseMatch
-        const paramNames = extractDynamicParamNames(match.value);
-        if (paramNames.length === 0) continue;
+    // responseRedactions is index-correlated with responseMatches.
+    const redaction = responseRedactions?.[i];
 
-        // Find corresponding redaction for this parameter
-        // Expecting only one redaction per parameter
-        const matchingRedaction = redaction;
+    let slices = [];
+    if (redaction && (redaction.xPath || redaction.jsonPath || redaction.regex)) {
+      try {
+        slices = resolveRedaction(responseText, redaction).map((entry) => entry.value);
 
-        if (matchingRedaction) {
-          let extractedValue = null;
-
-          // Try to extract using jsonPath if available and response is JSON
-          if (matchingRedaction.jsonPath && jsonData) {
-            extractedValue = getValueFromJsonPath(jsonData, matchingRedaction.jsonPath);
-          }
-          // Try to extract using xPath if available and response is HTML
-          else if (matchingRedaction.xPath && !isJson) {
-            extractedValue = getValueFromXPath(responseText, matchingRedaction.xPath);
-          }
-          // Fall back to regex extraction
-          else if (matchingRedaction.regex) {
-            const regexMatch = responseText.match(new RegExp(matchingRedaction.regex));
-            if (regexMatch) {
-              // Prefer the named capture group matching the param name (e.g. `(?<echouser>...)`),
-              // falling back to positional group 1 for redactions without named groups.
-              if (regexMatch.groups && regexMatch.groups[paramNames[0]] !== undefined) {
-                extractedValue = regexMatch.groups[paramNames[0]];
-              } else if (regexMatch.length > 1) {
-                extractedValue = regexMatch[1];
-              }
-            }
-          }
-
-          // Store the extracted value as string
-          if (extractedValue !== undefined) {
-            // Convert objects and arrays to JSON string, primitives to regular string
-            if (typeof extractedValue === "object" && extractedValue !== null) {
-              paramValues[paramNames[0]] = JSON.stringify(extractedValue);
-            } else if (extractedValue === null) {
-              paramValues[paramNames[0]] = null;
-            } else {
-              paramValues[paramNames[0]] = String(extractedValue);
-            }
-          }
+        // The success half of the chain. Until this existed, only *failures*
+        // were reported (reportExtractionFailure in the background), so a
+        // selector that resolved to the wrong region — or to an empty string —
+        // was indistinguishable from one that was never evaluated. Selector
+        // text is provider-authored; the resolved content is the user's, so
+        // only its shape appears here and the values themselves ride the
+        // payload, which is blanked at INFO and raw at FINE.
+        logger?.info?.(
+          `[PARAM-EXTRACTOR] Redaction #${i} resolved via ${describeRedaction(redaction)} → ${slices.length} slice(s) [${slices
+            .map((slice) => `len=${String(slice ?? "").length}`)
+            .join(", ")}]`,
+          "claim.params",
+          { payload: { extractedParameters: slices } },
+        );
+      } catch (error) {
+        if (alreadyKnown) {
+          logger?.debug?.(
+            `[PARAM-EXTRACTOR] Redaction for already-known param(s) ${paramNames.join(", ")} did not resolve: ${error.message}`,
+            "claim.params",
+          );
+          continue;
         }
+        throw error;
       }
     }
-  } catch (error) {
-    console.error("[PARAM-EXTRACTOR] Error extracting params from response:", error);
+
+    // Names and lengths only — see the note on the redaction line above.
+    const reportResolved = (via, values) =>
+      logger?.info?.(
+        `[PARAM-EXTRACTOR] responseMatch #${i} resolved via ${via}: ${Object.entries(values)
+          .map(([name, value]) => `${name}(len=${String(value ?? "").length})`)
+          .join(", ")}`,
+        "claim.params",
+        { payload: { extractedParameters: values } },
+      );
+
+    // A hashed redaction reveals only its capture group, so that slice *is* the
+    // value — there is no surrounding text to match a template against.
+    if (redaction?.hash && paramNames.length === 1 && slices.length) {
+      paramValues[paramNames[0]] = slices[0];
+      reportResolved(`hashed redaction (${redaction.hash})`, { [paramNames[0]]: slices[0] });
+      continue;
+    }
+
+    // A template that is nothing but a single placeholder has no surrounding
+    // text to anchor a match against, so the resolved slice is the value.
+    if (paramNames.length === 1 && match.value.trim() === `{{${paramNames[0]}}}` && slices.length) {
+      paramValues[paramNames[0]] = slices[0];
+      reportResolved("the resolved slice", { [paramNames[0]]: slices[0] });
+      continue;
+    }
+
+    const built = buildTemplateRegex(match.value, match.type, paramNames);
+    if (!built) {
+      if (alreadyKnown) continue;
+      throw new RedactionResolveError(
+        `Could not build an extraction regex for responseMatch "${match.value}"`,
+        { stage: "responseMatch" },
+      );
+    }
+
+    // Prefer the revealed slice — it guarantees the value came from the region
+    // the attestor reveals. Fall back to the full body, since providers often
+    // author responseMatches against the whole response while the redaction
+    // only narrows the reveal.
+    const found = firstTemplateMatch(built, [...slices, responseText], paramNames);
+
+    if (!found) {
+      if (alreadyKnown) continue;
+      throw new RedactionResolveError(
+        `responseMatch "${match.value}" did not match the resolved response region`,
+        { stage: "responseMatch" },
+      );
+    }
+
+    Object.assign(paramValues, found);
+    reportResolved(`template "${match.value}"`, found);
   }
 
+  // Confirms the chain actually produced values, and how long each is. The
+  // VALUES are deliberately absent from the message: this is the user's
+  // extracted data, and a length is enough to tell "matched but empty" from
+  // "matched correctly", which is the question this line exists to answer. INFO
+  // rather than FINE because a wrong-but-plausible extraction is otherwise
+  // invisible until the attestor rejects the claim minutes later.
+  logger?.info?.(
+    `[PARAM-EXTRACTOR] Resolved ${Object.keys(paramValues).length} param(s): ${Object.entries(
+      paramValues,
+    )
+      .map(([name, value]) => `${name}(len=${String(value ?? "").length})`)
+      .join(", ")}`,
+    "claim.params",
+    { payload: { extractedParameters: paramValues } },
+  );
+
   return paramValues;
+};
+
+/**
+ * Run the built regex against each haystack in turn, returning the first match
+ * that yields a value for every requested param.
+ *
+ * @param {{regex: RegExp, named: boolean}} built
+ * @param {string[]} haystacks
+ * @param {string[]} paramNames
+ * @returns {Object|null} param name -> value
+ */
+const firstTemplateMatch = ({ regex, named }, haystacks, paramNames) => {
+  for (const haystack of haystacks) {
+    if (typeof haystack !== "string" || !haystack) continue;
+
+    // makeRegex sets `g`, so lastIndex carries over between calls.
+    regex.lastIndex = 0;
+    const result = regex.exec(haystack);
+    if (!result) continue;
+
+    const values = {};
+    let complete = true;
+    for (let i = 0; i < paramNames.length; i++) {
+      const name = paramNames[i];
+      // Positional groups are ordered by placeholder, hence index + 1.
+      const value = named ? result.groups?.[name] : result[i + 1];
+      if (value === undefined) {
+        complete = false;
+        break;
+      }
+      values[name] = value;
+    }
+    // A partial match against the narrow slice can still match fully against
+    // the full body, so keep going rather than giving up here.
+    if (complete) return values;
+  }
+  return null;
 };
 
 /**
@@ -176,6 +351,12 @@ export const extractParamsFromResponse = (
  * @param {Array} responseMatches
  * @param {Array} responseRedactions
  * @returns {Set<string>}
+ */
+/**
+ * NOTE: do NOT use this to force params into `secretParams`. Doing so breaks
+ * OPRF — see the long comment at the separateParams call site in
+ * claim-creator.js. Kept because knowing which params are hashed is useful for
+ * diagnostics.
  */
 export const getHashedParamNames = (responseMatches, responseRedactions) => {
   const hashed = new Set();

--- a/src/utils/claim-creator/vendor/attestor-http-utils.js
+++ b/src/utils/claim-creator/vendor/attestor-http-utils.js
@@ -1,0 +1,257 @@
+/**
+ * VENDORED — DO NOT "IMPROVE" THIS FILE.
+ *
+ * Verbatim port of the extraction half of attestor-core
+ * `src/providers/http/utils.ts` as of @reclaimprotocol/attestor-core@5.0.8.
+ * The extraction code is byte-identical across 5.0.5 → 5.1.1, and on the
+ * current 5.1.1 pin that is no longer an assertion: attestor-parity.test.js
+ * drives the installed package's own `./external-rpc` surface and diffs it
+ * against this copy on every `npm test`.
+ *
+ * Why still vendored rather than imported now that 5.1.1 exports the
+ * extractors (PR #92): `makeRegex` and the `processRedactionRequest` redaction
+ * chain are still not in that export set, so local copies are needed either
+ * way — and a half-imported, half-copied chain is harder to keep in lockstep
+ * than a wholly copied one the parity test can check end to end.
+ *
+ * The point of this file is that a provider's `xPath` / `jsonPath` resolves
+ * identically here, in the attestor, and in the InApp SDK. Editing it breaks
+ * that. To re-sync: re-copy from upstream, keep the deviation noted on
+ * `makeRegex` below, and run `npm test`.
+ *
+ * ONE DELIBERATE DEVIATION: `makeRegex` uses native RegExp rather than RE2.
+ * That is what the attestor itself does in browsers — its esbuild browser
+ * build aliases `re2` to `src/scripts/fallbacks/re2.ts`, which is
+ * `new RegExp(pattern, flags.replace('u',''))`. RE2 is not an option here
+ * anyway: webpack.config.js aliases `re2: false`.
+ *
+ * Omitted from the port (not needed by the extension, all TLS-transcript
+ * concerns): buildHeaders, convertResponsePosToAbsolutePos,
+ * getRedactionsForChunkHeaders, parseHttpResponse, matchRedactedStrings,
+ * generateRequstAndResponseFromTranscript.
+ */
+
+import "./patch-parse5-tree.js";
+
+import { JSONPath } from "jsonpath-plus";
+import { parse } from "parse5";
+import { adapter as htmlAdapter } from "parse5-htmlparser2-tree-adapter";
+import xpath from "xpath";
+import {
+  ArrayExpression,
+  ExpressionStatement,
+  ObjectExpression,
+  parseScript,
+  Property,
+  Syntax,
+} from "esprima-next";
+
+/**
+ * Returns only first extracted element
+ * @param {string} html
+ * @param {string} xpathExpression
+ * @param {boolean} contentsOnly
+ * @returns {string}
+ */
+export function extractHTMLElement(html, xpathExpression, contentsOnly) {
+  const { start, end } = extractHTMLElementIndex(html, xpathExpression, contentsOnly);
+  return html.slice(start, end);
+}
+
+/**
+ * Returns all extracted elements
+ * @param {string} html
+ * @param {string} xpathExpression
+ * @param {boolean} contentsOnly
+ * @returns {string[]}
+ */
+export function extractHTMLElements(html, xpathExpression, contentsOnly) {
+  const indexes = extractHTMLElementsIndexes(html, xpathExpression, contentsOnly);
+  const res = [];
+  for (const { start, end } of indexes) {
+    res.push(html.slice(start, end));
+  }
+
+  return res;
+}
+
+/**
+ * returns a single index of extracted element
+ * @param {string} html
+ * @param {string} xpathExpression
+ * @param {boolean} contentsOnly
+ * @returns {{ start: number, end: number }}
+ */
+export function extractHTMLElementIndex(html, xpathExpression, contentsOnly) {
+  return extractHTMLElementsIndexes(html, xpathExpression, contentsOnly)[0];
+}
+
+/**
+ * Returns indexes of all extracted elements
+ * @param {string} html
+ * @param {string} xpathExpression
+ * @param {boolean} contentsOnly indices of the start and end of the element's
+ *  contents only, not the whole tag
+ * @returns {{ start: number, end: number }[]}
+ */
+export function extractHTMLElementsIndexes(html, xpathExpression, contentsOnly) {
+  return extractHTMLElementIndexesParse5(html, xpathExpression, contentsOnly);
+}
+
+function extractHTMLElementIndexesParse5(html, xpathExpression, contentsOnly) {
+  const domLight = parse(html, { treeAdapter: htmlAdapter, sourceCodeLocationInfo: true });
+  // lets xpath identify this as a node
+  domLight["name"] = "root";
+
+  const parsedPath = xpath.parse(xpathExpression);
+  const nodes = parsedPath.select({
+    node: domLight,
+    allowAnyNamespaceForNoPrefix: true,
+  });
+  if (!nodes.length) {
+    throw new Error(`Failed to find XPath: "${xpathExpression}"`);
+  }
+
+  return nodes.map((node) => getNodeRange(node, contentsOnly));
+}
+
+function getNodeRange(node, contentsOnly) {
+  if (!contentsOnly) {
+    return { start: node.startIndex, end: node.endIndex };
+  }
+
+  if (!("firstChild" in node) || !node.firstChild) {
+    throw new Error(`Node "${node["name"]}" has no children`);
+  }
+
+  return {
+    start: node.firstChild.startIndex,
+    end: node.lastChild.endIndex,
+  };
+}
+
+/**
+ * @param {string} json
+ * @param {string} jsonPath
+ * @returns {{ start: number, end: number }}
+ */
+export function extractJSONValueIndex(json, jsonPath) {
+  return extractJSONValueIndexes(json, jsonPath)[0];
+}
+
+/**
+ * @param {string} json
+ * @param {string} jsonPath
+ * @returns {{ start: number, end: number }[]}
+ */
+export function extractJSONValueIndexes(json, jsonPath) {
+  const pointers = JSONPath({
+    path: jsonPath,
+    json: JSON.parse(json),
+    wrap: false,
+    resultType: "pointer",
+    eval: "safe",
+    ignoreEvalErrors: true,
+  });
+  if (!pointers) {
+    throw new Error("jsonPath not found");
+  }
+
+  //wrap in parentheses for esprima to parse
+  const tree = parseScript("(" + json + ")", { range: true });
+  if (
+    tree.body[0] instanceof ExpressionStatement &&
+    (tree.body[0].expression instanceof ObjectExpression ||
+      tree.body[0].expression instanceof ArrayExpression)
+  ) {
+    const traversePointers = Array.isArray(pointers) ? pointers : [pointers];
+    const res = [];
+    for (const pointer of traversePointers) {
+      const index = traverse(tree.body[0].expression, "", [pointer]);
+      if (index) {
+        res.push({
+          start: index.start - 1, //account for '('
+          end: index.end - 1,
+        });
+      }
+    }
+
+    return res;
+  }
+
+  throw new Error("jsonPath not found");
+}
+
+/**
+ * recursively go through AST tree and build a JSON path while it's not equal to
+ * the one we search for
+ * @param {object} o - esprima expression for root object
+ * @param {string} path - path that is being built
+ * @param {string[]} pointers - JSON pointers to compare to
+ * @returns {{ start: number, end: number } | null}
+ */
+function traverse(o, path, pointers) {
+  if (o instanceof ObjectExpression) {
+    for (const p of o.properties) {
+      if (!(p instanceof Property)) {
+        continue;
+      }
+
+      const localPath = p.key.type === Syntax.Literal ? path + "/" + p.key.value : path;
+
+      if (pointers.includes(localPath) && "range" in p && Array.isArray(p.range)) {
+        return {
+          start: p.range[0],
+          end: p.range[1],
+        };
+      }
+
+      if (p.value instanceof ObjectExpression || p.value instanceof ArrayExpression) {
+        const res = traverse(p.value, localPath, pointers);
+        if (res) {
+          return res;
+        }
+      }
+    }
+  }
+
+  if (o instanceof ArrayExpression) {
+    for (let i = 0; i < o.elements.length; i++) {
+      const element = o.elements[i];
+      if (!element) {
+        continue;
+      }
+
+      const localPath = path + "/" + i;
+
+      if (pointers.includes(localPath) && "range" in element && Array.isArray(element.range)) {
+        return {
+          start: element.range[0],
+          end: element.range[1],
+        };
+      }
+
+      if (element instanceof ObjectExpression) {
+        const res = traverse(element, localPath, pointers);
+        if (res) {
+          return res;
+        }
+      }
+
+      if (element instanceof ArrayExpression) {
+        const res = traverse(element, localPath, pointers);
+        if (res) {
+          return res;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+// Upstream defines makeRegex in this file. It lives in ../make-regex.js here so
+// the content script can share the attestor's regex flags without pulling the
+// parsers above into a bundle injected on every page. Re-exported so this module
+// still presents upstream's surface.
+export { makeRegex } from "../make-regex.js";

--- a/src/utils/claim-creator/vendor/patch-parse5-tree.js
+++ b/src/utils/claim-creator/vendor/patch-parse5-tree.js
@@ -1,0 +1,51 @@
+/**
+ * VENDORED — DO NOT "IMPROVE" THIS FILE.
+ *
+ * Verbatim port of attestor-core `src/providers/http/patch-parse5-tree.ts`
+ * as of @reclaimprotocol/attestor-core@5.0.8 (identical in 5.0.5 through 5.1.1).
+ *
+ * These patches are required to make the `xpath` package work with a parse5
+ * tree: `xpath` expects DOM-ish nodes (`nodeName`, `localName`,
+ * `attributes.item()`), and domhandler nodes don't provide them.
+ *
+ * Any local edit here silently breaks cross-SDK xPath parity — the whole point
+ * of vendoring is that a provider's xPath resolves identically in the attestor,
+ * the InApp SDK and this extension. To re-sync, re-copy from upstream and run
+ * `npm test` (see attestor-extraction.test.js).
+ */
+
+import { Element, Node } from "domhandler";
+
+Element.prototype.toString = function () {
+  throw new Error("Element.toString() is not supported");
+};
+
+Object.defineProperty(Node.prototype, "nodeName", {
+  get: function () {
+    return this.name;
+  },
+});
+
+Object.defineProperty(Node.prototype, "localName", {
+  get: function () {
+    return this.name;
+  },
+});
+
+const origAttributes = Object.getOwnPropertyDescriptor(Element.prototype, "attributes")?.get;
+
+if (origAttributes) {
+  Object.defineProperty(Element.prototype, "attributes", {
+    get: function (...args) {
+      const attrs = origAttributes.call(this, ...args);
+      attrs.item = (idx) => {
+        const el = attrs[idx];
+        return { ...el, nodeType: 2, localName: el.name };
+      };
+
+      return attrs;
+    },
+  });
+} else {
+  console.warn("[WARN] Unable to patch DOM: Element.attributes property descriptor not found");
+}

--- a/src/utils/claim-progress.js
+++ b/src/utils/claim-progress.js
@@ -1,0 +1,32 @@
+/**
+ * Session-wide claim progress for the in-page popup.
+ *
+ * The popup cannot count this itself. It lives in the content script, which is
+ * destroyed and rebuilt at `document_start` on every navigation — and a
+ * multi-request provider routinely spans several origins (the `example`
+ * provider walks example.org -> example.com -> jsonplaceholder). Each new page
+ * got a popup with `totalClaims: 0` that then counted only the events arriving
+ * after it was built, so a real 3-claim session displayed `1/1`, flashed `2/1`,
+ * and finished by printing `totalClaims/totalClaims` — `1/1` again.
+ *
+ * The background is the only context that survives those navigations, so it is
+ * the only place these numbers are real. It sends them with
+ * CLAIM_CREATION_REQUESTED and PROOF_GENERATION_SUCCESS.
+ *
+ * Its own module rather than a function in background.js so it is reachable
+ * from `node --test`: background.js uses extensionless imports, which webpack
+ * resolves and Node's ESM loader does not.
+ *
+ * @param {{generatedProofs?: Map<string, unknown>, providerData?: {requestData?: unknown[]}}} ctx
+ * @returns {{completed: number, total: number}}
+ */
+export function claimProgress(ctx) {
+  const completed = ctx?.generatedProofs?.size ?? 0;
+  const declared = Array.isArray(ctx?.providerData?.requestData)
+    ? ctx.providerData.requestData.length
+    : 0;
+  // `total` takes the larger of the two: with `expectManyClaims` a provider
+  // script can produce more claims than `requestData` declares, and a counter
+  // that reads `4/3` is worse than one that grows.
+  return { completed, total: Math.max(declared, completed) };
+}

--- a/src/utils/claim-progress.test.js
+++ b/src/utils/claim-progress.test.js
@@ -1,0 +1,66 @@
+/**
+ * The popup's claim counter, for the case that broke it.
+ *
+ * Session 2b46b57c39 ran the `example` provider: three requestData entries
+ * across three ORIGINS (example.org -> example.com -> jsonplaceholder). All
+ * three claims and proofs succeeded, but the popup showed `1/1`, flashed
+ * `2/1`, and settled back on `1/1`.
+ *
+ * The cause was not the counting logic — it was WHERE the counting lived. The
+ * popup belongs to the content script, which Chrome tears down and rebuilds at
+ * `document_start` on every navigation, so each new page got a fresh
+ * `{ totalClaims: 0, completedClaims: 0 }` and could only see the events that
+ * arrived after it existed. The last page saw one claim request and three proof
+ * successes: 1/1, 2/1, 3/1 — then `showSuccess()` printed
+ * `totalClaims/totalClaims`, i.e. 1/1 again.
+ *
+ * These tests pin the replacement: the background computes progress from state
+ * that survives navigation, and the popup only renders it.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import { claimProgress } from "./claim-progress.js";
+
+/** A ctx as background.js builds it, mid-session. */
+const ctx = (proofCount, requestDataCount) => ({
+  generatedProofs: new Map(
+    Array.from({ length: proofCount }, (_, i) => [`0xhash${i}`, { proof: i }]),
+  ),
+  providerData: { requestData: Array.from({ length: requestDataCount }, () => ({})) },
+});
+
+describe("claimProgress", () => {
+  it("reports the provider's full request count from the very first claim", () => {
+    // The whole point: at the moment the FIRST claim is requested the
+    // denominator is already 3, so a popup built on page 3 of 3 still renders
+    // the session's totals rather than its own page's.
+    assert.deepEqual(claimProgress(ctx(0, 3)), { completed: 0, total: 3 });
+  });
+
+  it("walks the example provider's session to 3/3", () => {
+    assert.deepEqual(claimProgress(ctx(1, 3)), { completed: 1, total: 3 });
+    assert.deepEqual(claimProgress(ctx(2, 3)), { completed: 2, total: 3 });
+    assert.deepEqual(claimProgress(ctx(3, 3)), { completed: 3, total: 3 });
+  });
+
+  it("never reports more completed than total", () => {
+    // What produced the nonsensical `2/1`. With expectManyClaims a provider
+    // script can generate more claims than requestData declares, so the total
+    // grows to meet them instead of the counter overflowing.
+    assert.deepEqual(claimProgress(ctx(4, 3)), { completed: 4, total: 4 });
+  });
+
+  it("survives provider data that is missing or malformed", () => {
+    // Runs before fetchProviderData resolves, and on the failure path.
+    assert.deepEqual(claimProgress({}), { completed: 0, total: 0 });
+    assert.deepEqual(claimProgress({ generatedProofs: new Map() }), { completed: 0, total: 0 });
+    assert.deepEqual(
+      claimProgress({ generatedProofs: new Map([["a", 1]]), providerData: {} }),
+      { completed: 1, total: 1 },
+      "a proof with no declared requestData still counts",
+    );
+    assert.deepEqual(claimProgress(undefined), { completed: 0, total: 0 });
+  });
+});

--- a/src/utils/constants/config.js
+++ b/src/utils/constants/config.js
@@ -7,11 +7,43 @@
 
 // --- Proof Generation ---
 
-/** Max time for attestor proof generation in offscreen document (ms) */
+/**
+ * ZK engine used when a provider doesn't specify one in
+ * `extensionConfig.zkEngine`.
+ *
+ * This must be an engine the pinned attestor-core's **prebuilt browser bundle**
+ * actually registers a ZK operator maker for, otherwise proof generation dies in
+ * the offscreen document with "No ZK operator maker for <engine>". The bundle is
+ * a checked-in artifact upstream and its engine support has silently changed
+ * between patch releases — see attestor-zk-engine.test.js, which guards this.
+ */
+export const DEFAULT_ZK_ENGINE = "stwo";
+
+/**
+ * Max time for attestor proof generation in offscreen document (ms).
+ *
+ * This is the real proof budget: offscreen.js races `createClaimOnAttestor`
+ * against it.
+ */
 export const PROOF_GENERATION_TIMEOUT_MS = 120000; // 2 minutes
 
-/** Max time waiting for proof generation response from offscreen (ms) */
-export const PROOF_RESPONSE_TIMEOUT_MS = 60000; // 1 minute
+/**
+ * Max time the background waits for the offscreen document's response (ms).
+ *
+ * **Must stay strictly greater than PROOF_GENERATION_TIMEOUT_MS**, hence the
+ * derivation rather than a literal. It was 60s against an inner 120s, so the
+ * outer timeout always won: a proof that legitimately needed 60–120s was killed
+ * by the background while the offscreen document was still working, and the
+ * inner timeout could never surface at all. The session then failed with the
+ * vaguer "Timeout waiting for offscreen document" instead of the offscreen's
+ * own "Proof generation timed out after 120 seconds".
+ *
+ * The headroom covers the PROOF_GENERATION_FAILED `updateSessionStatus` POST
+ * the offscreen makes on its way out, plus the chrome-messaging hop. This
+ * timeout is now only a backstop for an offscreen document that died without
+ * answering at all.
+ */
+export const PROOF_RESPONSE_TIMEOUT_MS = PROOF_GENERATION_TIMEOUT_MS + 15000; // 2m15s
 
 /** Max time waiting for private key generation from offscreen (ms) */
 export const PRIVATE_KEY_TIMEOUT_MS = 10000; // 10 seconds
@@ -65,6 +97,37 @@ export const LOG_FLUSH_INTERVAL_MS = 5000; // 5 seconds
 
 /** Time window for log deduplication (ms) */
 export const LOG_DEDUPE_WINDOW_MS = 100; // 100 ms
+
+/**
+ * Periodic flush period when `chrome.alarms` is used instead of setInterval.
+ * Chrome clamps alarm periods to a 30-second minimum in released extensions, so
+ * this is the floor, not a preference. The alarm is a backstop against worker
+ * death — batch-size and terminal-event flushes do the routine work.
+ */
+export const LOG_FLUSH_ALARM_PERIOD_MINUTES = 0.5;
+
+/**
+ * Max characters of a single log line kept before truncation.
+ *
+ * Matches the InApp SDK's cap. Without it, one `JSON.stringify(providerData)`
+ * can be hundreds of kilobytes, which is why the logs backend needs
+ * `splitLargeEntry` at all — and an oversized batch is more likely to be
+ * rejected outright, taking every other log in the batch with it.
+ */
+export const LOG_MAX_LINE_LENGTH = 2000;
+
+/**
+ * Cap for a log line carrying a RAW payload, i.e. one emitted at FINE.
+ *
+ * Deliberately far above LOG_MAX_LINE_LENGTH: a real claim — request body
+ * template, cookie header, response redactions — runs well past 2000
+ * characters, so the normal cap would cut off exactly the half being asked for.
+ *
+ * Finite rather than absent, though. An oversized POST is rejected outright, and
+ * a rejected batch stays queued for retry, so one runaway payload would block
+ * every later batch behind it. This bounds that without truncating a real claim.
+ */
+export const LOG_MAX_UNREDACTED_LINE_LENGTH = 100_000;
 
 // --- Custom Injection ---
 

--- a/src/utils/constants/interfaces.js
+++ b/src/utils/constants/interfaces.js
@@ -30,6 +30,14 @@ export const RECLAIM_SDK_ACTIONS = {
   REQUEST_CLAIM: "RECLAIM_REQUEST_CLAIM",
   SET_LOG_CONFIG: "RECLAIM_SET_LOG_CONFIG",
   LOG_CONFIG_UPDATED: "RECLAIM_LOG_CONFIG_UPDATED",
+  // MAIN-world → content-script log relay. The interceptor and the injection
+  // scripts run in the page's own world with no `chrome.runtime`, so this is
+  // the only way their diagnostics reach the hub. See LOG_BRIDGE in
+  // src/interceptor/log-bridge.js.
+  LOG: "RECLAIM_LOG",
+  // Content script → MAIN world: pushes the log config down, since the page
+  // world cannot read chrome.storage to find out whether the console is enabled.
+  LOG_CONFIG: "RECLAIM_LOG_CONFIG",
 };
 
 export const RECLAIM_SESSION_STATUS = {

--- a/src/utils/fetch-calls.js
+++ b/src/utils/fetch-calls.js
@@ -1,10 +1,20 @@
 import { API_ENDPOINTS, RECLAIM_SESSION_STATUS } from "./constants";
+import { withClientSource } from "./logger/client-source";
 
 // Note: This file is used by both background and offscreen contexts.
 // Logging is handled by the caller to avoid duplicate log instances.
+//
+// Every request carries the `reclaim-api-client` header, the same header the
+// InApp SDK and Verifier app send, so extension traffic is attributable
+// server-side. This is identification only — per the team's guideline the
+// extension contributes no device information to analytics, so the request
+// bodies are unchanged and `deviceId`/`deviceType` stay absent (the backend
+// records them as "NA").
 
 export const fetchProviderData = async (providerId, sessionId, appId) => {
-  const response = await fetch(`${API_ENDPOINTS.PROVIDER_URL(providerId)}`);
+  const response = await fetch(`${API_ENDPOINTS.PROVIDER_URL(providerId)}`, {
+    headers: withClientSource(),
+  });
   if (!response.ok) {
     throw new Error("Failed to fetch provider data");
   }
@@ -15,7 +25,7 @@ export const fetchProviderData = async (providerId, sessionId, appId) => {
 export const updateSessionStatus = async (sessionId, status, providerId, appId) => {
   const response = await fetch(`${API_ENDPOINTS.UPDATE_SESSION_STATUS()}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: withClientSource({ "Content-Type": "application/json" }),
     body: JSON.stringify({ sessionId, status }),
   });
 
@@ -30,6 +40,12 @@ export const updateSessionStatus = async (sessionId, status, providerId, appId) 
 export const submitProofOnCallback = async (proofs, submitUrl, sessionId, providerId, appId) => {
   const jsonStringOfProofs = JSON.stringify(proofs);
   const urlEncodedProofs = encodeURIComponent(jsonStringOfProofs);
+  // NOTE: deliberately no `reclaim-api-client` header here. `submitUrl` is the
+  // consumer's own callback endpoint, not a Reclaim API. `Content-Type:
+  // text/plain` is CORS-safelisted, so this is currently a "simple" request
+  // with no preflight; adding a custom header would force an OPTIONS preflight
+  // that arbitrary consumer servers are not required to answer, breaking proof
+  // submission. The header also tells the consumer nothing they need.
   const response = await fetch(submitUrl, {
     method: "POST",
     headers: { "Content-Type": "text/plain" },

--- a/src/utils/logger/LoggingHub.js
+++ b/src/utils/logger/LoggingHub.js
@@ -475,11 +475,17 @@ class LoggingHub {
           : resolvedLevel === "WARNING"
             ? console.warn
             : console.log;
-      const prefix = `[${resolvedLevel}] [${context}]${type ? ` [${type}]` : ""} ${message}`;
+      // Literal format string, `message` passed as an argument — see the note
+      // in log-bridge.js. A message carrying "%s" otherwise consumes the
+      // payload and corrupts the line.
+      const format = type ? "[%s] [%s] [%s] %s" : "[%s] [%s] %s";
+      const parts = type
+        ? [resolvedLevel, context, type, message]
+        : [resolvedLevel, context, message];
       if (hasPayload) {
-        consoleFn(prefix, consolePayload);
+        consoleFn(format, ...parts, consolePayload);
       } else {
-        consoleFn(prefix);
+        consoleFn(format, ...parts);
       }
     }
 

--- a/src/utils/logger/LoggingHub.js
+++ b/src/utils/logger/LoggingHub.js
@@ -1,8 +1,27 @@
 /**
- * LoggingHub - Centralized logging hub for background service worker
+ * LoggingHub - the single sink for every log the SDK produces.
  *
- * All logs from background, content, and offscreen are routed through this hub.
- * The hub maintains session context and enriches all logs before batching and sending to API.
+ * Background logs to it directly; content, offscreen and the MAIN-world
+ * interceptor reach it through `handleRemoteLog` (see RemoteLogger and the
+ * RECLAIM_LOG bridge in content.js). Everything is enriched with one session
+ * context, batched, and POSTed to the diagnostic endpoint.
+ *
+ * ONE threshold, `config.logLevel`, governing both destinations:
+ *
+ *   INFO (default) — the whole session, values REDACTED. Console (when
+ *                    enabled) and the endpoint receive the same redacted text.
+ *   FINE           — the whole session, values RAW: response bodies, extracted
+ *                    parameters, the full claim and proof. Also sent to the
+ *                    endpoint, which is the point — it is how a client's failing
+ *                    session is diagnosed remotely, with their permission.
+ *
+ * `config.consoleEnabled` is independent and only decides whether lines are
+ * mirrored to this context's console; it never changes what is collected.
+ *
+ * The queue is mirrored into `chrome.storage.session` on every change. An MV3
+ * service worker is killed without warning and `chrome.runtime.onSuspend` does
+ * not reliably fire, so an in-memory-only queue loses exactly the logs that
+ * explain a crash. On the next start `_drainPersisted()` picks them back up.
  */
 
 import {
@@ -10,16 +29,35 @@ import {
   LOG_LEVEL,
   DEFAULT_LOG_CONFIG,
   LOG_CONFIG_STORAGE_KEY,
-} from "./constants";
+  LOG_QUEUE_STORAGE_KEY,
+  LOG_FLUSH_ALARM_NAME,
+  normalizeLogLevel,
+} from "./constants.js";
+import { getClientSource, withClientSource } from "./client-source.js";
+import { redact, redactedJson, unredactedJson } from "./redact.js";
 import {
   LOG_MAX_BATCH_SIZE,
   LOG_MAX_QUEUE_SIZE,
   LOG_FLUSH_INTERVAL_MS,
   LOG_DEDUPE_WINDOW_MS,
-} from "../constants/config";
+  LOG_FLUSH_ALARM_PERIOD_MINUTES,
+  LOG_MAX_LINE_LENGTH,
+  LOG_MAX_UNREDACTED_LINE_LENGTH,
+} from "../constants/config.js";
 
 // Singleton guard to prevent multiple instances
 let singletonInstance = null;
+
+/**
+ * Cap a log line, keeping both ends. The head says what happened and the tail
+ * usually holds the error; cutting only the tail loses half of that.
+ */
+function truncateLine(message, max = LOG_MAX_LINE_LENGTH) {
+  const text = typeof message === "string" ? message : String(message ?? "");
+  if (text.length <= max) return text;
+  const keep = Math.floor((max - 40) / 2);
+  return `${text.slice(0, keep)}… [${text.length - keep * 2} chars truncated] …${text.slice(-keep)}`;
+}
 
 class LoggingHub {
   constructor() {
@@ -33,6 +71,11 @@ class LoggingHub {
       providerId: null,
       appId: null,
     };
+    // Set once a terminal path has flushed; the identifiers survive so late
+    // logs stay findable. See clearSessionContext().
+    this.sessionEnded = false;
+    this._contextSetExplicitly = false;
+    this._flushChain = null;
     this.logs = [];
     this.deviceId = null;
     this.maxBatchSize = LOG_MAX_BATCH_SIZE;
@@ -41,7 +84,8 @@ class LoggingHub {
     this.flushIntervalId = null;
     this.isFlushing = false;
 
-    // Deduplication: Map of logHash -> timestamp (ms)
+    // Deduplication: logHash -> { ts, entry }. Keeping the entry reference lets
+    // a repeat bump a counter on the queued line instead of vanishing.
     this._recentLogHashes = new Map();
     this._dedupeWindowMs = LOG_DEDUPE_WINDOW_MS;
 
@@ -51,25 +95,47 @@ class LoggingHub {
       totalLogsSent: 0,
       totalLogsDropped: 0,
       totalDeduplicated: 0,
+      totalRestored: 0,
       flushCount: 0,
     };
 
     // Log config (log level + console output)
     this.config = { ...DEFAULT_LOG_CONFIG };
 
-    // Ready promise - resolves when async init completes
-    this.ready = this._init();
+    // Async init is deferred until this hub is actually used. `background.js`
+    // is imported at module scope by `ReclaimExtensionSDK.js`, so constructing
+    // the hub eagerly would start a flush schedule in every consumer popup and
+    // web page that only ever calls the public API. `ready` stays a promise
+    // from the outside either way.
+    this._started = false;
+    this.ready = Promise.resolve();
 
     singletonInstance = this;
   }
 
   /**
-   * Run all async initialization and start flush interval
+   * Start async init exactly once, on first real use.
+   * @returns {Promise<void>}
+   */
+  _ensureStarted() {
+    if (this._started) return this.ready;
+    this._started = true;
+    this.ready = this._init();
+    return this.ready;
+  }
+
+  /**
+   * Run all async initialization and start the flush schedule
    */
   async _init() {
-    await Promise.all([this._initDeviceId(), this._restoreSessionContext(), this._loadConfig()]);
+    await Promise.all([
+      this._initDeviceId(),
+      this._restoreSessionContext(),
+      this._loadConfig(),
+      this._drainPersisted(),
+    ]);
     this._watchConfigChanges();
-    this._startFlushInterval();
+    this._startFlushSchedule();
   }
 
   /**
@@ -95,11 +161,52 @@ class LoggingHub {
   async _restoreSessionContext() {
     try {
       const result = await chrome.storage.session?.get("reclaim_log_session_context");
-      if (result?.reclaim_log_session_context) {
+      // Never clobber a context the caller set while this read was in flight.
+      if (result?.reclaim_log_session_context && !this._contextSetExplicitly) {
         this.sessionContext = result.reclaim_log_session_context;
       }
     } catch {
       // chrome.storage.session may not be available, ignore
+    }
+  }
+
+  /**
+   * Recover logs queued by a previous service-worker lifetime.
+   *
+   * These are prepended: they are older than anything this lifetime has
+   * produced, and the endpoint reads the batch in order.
+   */
+  async _drainPersisted() {
+    try {
+      const stored = await chrome.storage.session?.get(LOG_QUEUE_STORAGE_KEY);
+      const pending = stored?.[LOG_QUEUE_STORAGE_KEY];
+      if (Array.isArray(pending) && pending.length > 0) {
+        this.logs.unshift(...pending);
+        this.stats.totalRestored += pending.length;
+        this._trimQueue();
+        await chrome.storage.session?.remove(LOG_QUEUE_STORAGE_KEY);
+      }
+    } catch {
+      // chrome.storage.session may not be available.
+    }
+  }
+
+  /**
+   * Mirror the pending queue so a worker teardown does not lose it.
+   *
+   * Fire-and-forget on purpose: `chrome.storage.session` is in-memory, so this
+   * is cheap, and awaiting it would put a storage round-trip in the path of
+   * every log call.
+   */
+  _persistQueue() {
+    try {
+      if (this.logs.length === 0) {
+        chrome.storage.session?.remove(LOG_QUEUE_STORAGE_KEY);
+      } else {
+        chrome.storage.session?.set({ [LOG_QUEUE_STORAGE_KEY]: this.logs });
+      }
+    } catch {
+      // Storage unavailable — the in-memory queue is still the primary path.
     }
   }
 
@@ -156,27 +263,75 @@ class LoggingHub {
   }
 
   /**
-   * Check if a log should be recorded based on level
-   * @param {string} level - Log level ("ERROR" | "WARN" | "INFO" | "DEBUG")
+   * Compare a level against a threshold. Lower number = higher severity.
+   * @param {string} level - Log level of the entry
+   * @param {string} threshold - Configured threshold name
    * @returns {boolean}
    */
-  _shouldLog(level) {
-    const configThreshold = LOG_LEVEL[this.config.logLevel] || LOG_LEVEL.INFO;
-    const requestedLevel = LOG_LEVEL[level] || LOG_LEVEL.INFO;
-    // Lower number = higher severity; log if severity <= threshold
-    return requestedLevel <= configThreshold;
+  _passes(level, threshold) {
+    const max = LOG_LEVEL[normalizeLogLevel(threshold)] || LOG_LEVEL.INFO;
+    const requested = LOG_LEVEL[normalizeLogLevel(level)] || LOG_LEVEL.INFO;
+    return requested <= max;
   }
 
   /**
-   * Start the periodic flush interval
+   * Whether this level is emitted at all.
+   *
+   * One threshold, both destinations. There is deliberately no separate remote
+   * threshold: two of them meant the console and the endpoint could disagree
+   * about what a session contained, and the remote one defaulted to the most
+   * verbose level, so everything shipped regardless of what the console showed.
+   *
+   * @param {string} level
+   * @returns {boolean}
    */
-  _startFlushInterval() {
-    if (this.flushIntervalId) {
-      clearInterval(this.flushIntervalId);
-    }
-    this.flushIntervalId = setInterval(() => this.flush(), this.flushIntervalMs);
+  _passesThreshold(level) {
+    return this._passes(level, this.config.logLevel);
+  }
 
-    // Also flush on service worker suspend
+  /**
+   * Whether payloads are serialised raw rather than redacted.
+   *
+   * True only at FINE. This is the single switch between "everything about the
+   * session, values blanked" and "everything about the session, values intact",
+   * and it governs the console and the endpoint alike.
+   *
+   * @returns {boolean}
+   */
+  _isRaw() {
+    return normalizeLogLevel(this.config.logLevel) === "FINE";
+  }
+
+  /**
+   * Start the periodic flush.
+   *
+   * `chrome.alarms` is preferred and used when the consumer's manifest grants
+   * the permission: a `setInterval` is destroyed along with the service worker,
+   * which is precisely when a flush is most needed. The interval remains as the
+   * fallback so no consumer manifest change is required.
+   */
+  _startFlushSchedule() {
+    const alarms = globalThis.chrome?.alarms;
+    if (alarms?.create) {
+      try {
+        alarms.create(LOG_FLUSH_ALARM_NAME, {
+          periodInMinutes: LOG_FLUSH_ALARM_PERIOD_MINUTES,
+        });
+        alarms.onAlarm.addListener((alarm) => {
+          if (alarm?.name === LOG_FLUSH_ALARM_NAME) this.flush();
+        });
+        this._usingAlarms = true;
+      } catch {
+        this._usingAlarms = false;
+      }
+    }
+
+    if (!this._usingAlarms) {
+      if (this.flushIntervalId) clearInterval(this.flushIntervalId);
+      this.flushIntervalId = setInterval(() => this.flush(), this.flushIntervalMs);
+    }
+
+    // Best-effort backstop. Not load-bearing: onSuspend often never fires.
     try {
       chrome.runtime.onSuspend?.addListener(() => {
         this.flush();
@@ -194,11 +349,18 @@ class LoggingHub {
    * @param {string} context.appId
    */
   setSessionContext({ sessionId, providerId, appId }) {
+    this._ensureStarted();
     this.sessionContext = {
       sessionId: sessionId || null,
       providerId: providerId || null,
       appId: appId || null,
     };
+    this.sessionEnded = false;
+    // `_init()` runs `_restoreSessionContext()` asynchronously. A caller that
+    // sets the context on a cold worker would otherwise have it overwritten by
+    // the previous session's persisted value a few microtasks later, silently
+    // filing this session's logs under the old id.
+    this._contextSetExplicitly = true;
 
     // Persist to chrome.storage.session for service worker restart recovery
     try {
@@ -211,83 +373,178 @@ class LoggingHub {
   }
 
   /**
-   * Clear session context - called when session ends or fails
+   * Clear session context - called when session ends or fails.
+   *
+   * Flushes first: entries already queued carry the session's identifiers, and
+   * a terminal event is exactly the point at which the worker is likely to be
+   * torn down. Without this the last and most diagnostic logs of a failed
+   * session are the ones most likely to be lost.
+   * @returns {Promise<void>}
    */
-  clearSessionContext() {
-    this.sessionContext = {
-      sessionId: null,
-      providerId: null,
-      appId: null,
-    };
+  async clearSessionContext() {
+    await this.forceFlush();
 
-    try {
-      chrome.storage.session?.remove("reclaim_log_session_context");
-    } catch {
-      // chrome.storage.session may not be available
+    // The identifiers are deliberately KEPT. A terminal path is not the last
+    // thing that logs: failSession() calls this and the flow then goes on to
+    // notify tabs, broadcast to the popup and answer further messages. Nulling
+    // the ids here stamped all of that "unknown", which does not merely lose
+    // attribution — it makes those lines unreachable from a `sessionId` query,
+    // i.e. invisible in exactly the view used to debug the failure.
+    //
+    // The cost is that a stray log emitted between two verifications is
+    // attributed to the finished session. That window is small (the next
+    // startVerification calls setSessionContext) and a slightly over-attributed
+    // line is far cheaper than a missing one.
+    this.sessionEnded = true;
+  }
+
+  /**
+   * Drop oldest logs if the queue exceeds its cap (prevents OOM on API outage)
+   */
+  _trimQueue() {
+    if (this.logs.length > this.maxQueueSize) {
+      const dropped = this.logs.length - this.maxQueueSize;
+      this.logs = this.logs.slice(dropped);
+      this.stats.totalLogsDropped += dropped;
     }
   }
 
   /**
-   * Internal method to add a log entry
-   * @param {string} message - Log message
+   * Internal method to add a log entry.
+   *
+   * Redaction follows the LEVEL, not the destination. One threshold decides
+   * both what is emitted and in what form, and the console and the endpoint
+   * then receive the same information:
+   *
+   *   logLevel INFO (default) -> `payload` is REDACTED. Values are blanked,
+   *                              key names kept, and the line is capped at
+   *                              LOG_MAX_LINE_LENGTH.
+   *   logLevel FINE           -> `payload` is RAW, capped at
+   *                              LOG_MAX_UNREDACTED_LINE_LENGTH so a real claim
+   *                              is not cut in half.
+   *
+   * The console gets the payload as a live object so devtools renders a tree;
+   * at INFO it is a redacted *copy*, so turning the console on never reveals
+   * more than the endpoint already holds.
+   *
+   * This replaced a destination-based split (console raw / endpoint redacted)
+   * plus a per-call `unredacted` opt-out. That arrangement could not express
+   * "no user data anywhere by default", because it left the console showing
+   * response bodies and extracted values at the default level.
+   *
+   * @param {string} message - Log message. MUST NOT embed user data: redaction
+   *   cannot reach inside a string that was already concatenated at the call
+   *   site. Pass structured data as `payload` instead.
    * @param {string} type - Log type/category
-   * @param {string} level - Log level ("ERROR" | "WARN" | "INFO" | "DEBUG")
+   * @param {string} level - "SEVERE" | "WARNING" | "INFO" | "FINE" (older
+   *   spellings ERROR/WARN/DEBUG are accepted and normalized)
+   * @param {string} [context] - Emitting context: background | content | offscreen | interceptor
+   * @param {Object} [options]
+   * @param {string} [options.eventType] - A value from EVENT_TYPES. This is the
+   *   cross-SDK lifecycle name; `type` is the dotted category used for
+   *   filtering. Both are useful: `eventType` answers "where in the flow", the
+   *   category answers "which module".
+   * @param {*} [options.payload] - Structured data. Pass the OBJECT, never a
+   *   pre-stringified blob: stringifying at the call site defeats redaction and
+   *   sends whatever it contains straight to the endpoint.
    */
-  _addLog(message, type, level = "INFO") {
-    // Filter by log level
-    if (!this._shouldLog(level)) {
+  _addLog(message, type, level = "INFO", context = "background", options = undefined) {
+    this._ensureStarted();
+
+    const resolvedLevel = normalizeLogLevel(level);
+    const { eventType, payload } = options || {};
+
+    if (!this._passesThreshold(resolvedLevel)) {
       return;
     }
 
-    // Console output if enabled
+    // Raw values only exist at FINE. At every other level the payload is
+    // redacted once, here, and that same redacted copy is what both the console
+    // and the endpoint see.
+    const raw = this._isRaw();
+    const hasPayload = payload !== undefined;
+    const consolePayload = hasPayload ? (raw ? payload : redact(payload)) : undefined;
+
+    // Console output if enabled. The context is included so a service-worker
+    // console shows at a glance whether a line came from background, content or
+    // offscreen — remote logs are relayed through this same path.
     if (this.config.consoleEnabled) {
       const consoleFn =
-        level === "ERROR" ? console.error : level === "WARN" ? console.warn : console.log;
-      consoleFn(`[${level}] ${message}`);
-    }
-
-    const now = Date.now();
-
-    // Deduplication: skip if we've seen this exact log within dedupeWindowMs
-    const logHash = `${message}|${type}`;
-    const lastSeen = this._recentLogHashes.get(logHash);
-    if (lastSeen !== undefined && now - lastSeen < this._dedupeWindowMs) {
-      this.stats.totalDeduplicated++;
-      return;
-    }
-    this._recentLogHashes.set(logHash, now);
-
-    // Periodically prune stale entries from the dedup map (every 100 entries)
-    if (this._recentLogHashes.size > 100) {
-      for (const [key, ts] of this._recentLogHashes) {
-        if (now - ts >= this._dedupeWindowMs) {
-          this._recentLogHashes.delete(key);
-        }
+        resolvedLevel === "SEVERE"
+          ? console.error
+          : resolvedLevel === "WARNING"
+            ? console.warn
+            : console.log;
+      const prefix = `[${resolvedLevel}] [${context}]${type ? ` [${type}]` : ""} ${message}`;
+      if (hasPayload) {
+        consoleFn(prefix, consolePayload);
+      } else {
+        consoleFn(prefix);
       }
     }
 
+    const line = hasPayload
+      ? raw
+        ? truncateLine(`${message} ${unredactedJson(payload)}`, LOG_MAX_UNREDACTED_LINE_LENGTH)
+        : truncateLine(`${message} ${redactedJson(payload)}`)
+      : truncateLine(message);
+    const now = Date.now();
+
+    // Deduplication guards against a tight loop flooding the batch. Keyed on
+    // context and level too: the same wording emitted from background and from
+    // offscreen (or at INFO and then at ERROR) are different events, and
+    // collapsing them loses the one that matters. A repeat within the window
+    // increments `repeated` on the queued entry rather than disappearing, so
+    // the count is still visible downstream.
+    const logHash = `${context}|${resolvedLevel}|${line}|${type}|${eventType || ""}`;
+    const seen = this._recentLogHashes.get(logHash);
+    if (seen !== undefined && now - seen.ts < this._dedupeWindowMs) {
+      this.stats.totalDeduplicated++;
+      if (seen.entry) {
+        seen.entry.repeated = (seen.entry.repeated || 1) + 1;
+      }
+      return;
+    }
+
     const entry = {
-      logLine: message,
+      logLine: line,
       ts: String(now * 1000000), // nanoseconds for Loki
-      logLevel: level,
+      // Canonical platform spelling (SEVERE/WARNING/INFO/FINE) so the log
+      // viewer's severity filter covers extension sessions too.
+      logLevel: resolvedLevel,
       type: type || "unknown",
+      // Cross-SDK lifecycle name (EVENT_TYPES), spelled the same as the InApp
+      // SDK's LogEventType so one query spans both. UNKNOWN, not omitted, so
+      // the field is always present for a Loki label.
+      eventType: eventType || "UNKNOWN",
+      // Which extension context emitted this: background | content | offscreen
+      // | interceptor. Distinct from `source`, which identifies the SDK build.
+      context,
+      // Versioned SDK identity on every entry, not just the batch envelope, so
+      // a single line lifted out of Loki is still attributable.
+      source: getClientSource(),
       sessionId: this.sessionContext.sessionId || "unknown",
       providerId: this.sessionContext.providerId || "unknown",
       appId: this.sessionContext.appId || "unknown",
       deviceId: this.deviceId || "unknown",
     };
 
-    this.logs.push(entry);
-    this.stats.totalLogsQueued++;
+    this._recentLogHashes.set(logHash, { ts: now, entry });
 
-    // Drop oldest logs if queue exceeds max size (prevents OOM on API outage)
-    if (this.logs.length > this.maxQueueSize) {
-      const dropped = this.logs.length - this.maxQueueSize;
-      this.logs = this.logs.slice(dropped);
-      this.stats.totalLogsDropped += dropped;
+    // Periodically prune stale entries from the dedup map (every 100 entries)
+    if (this._recentLogHashes.size > 100) {
+      for (const [key, value] of this._recentLogHashes) {
+        if (now - value.ts >= this._dedupeWindowMs) {
+          this._recentLogHashes.delete(key);
+        }
+      }
     }
 
-    // Trigger flush if batch size reached
+    this.logs.push(entry);
+    this.stats.totalLogsQueued++;
+    this._trimQueue();
+    this._persistQueue();
+
     if (this.logs.length >= this.maxBatchSize) {
       this.flush();
     }
@@ -299,80 +556,125 @@ class LoggingHub {
    * Log an error message (highest severity - always logged)
    * @param {string} message - Log message
    * @param {string} type - Log type/category
+   * @param {Object} [options] - `{ eventType, payload }`; see _addLog
    */
-  error(message, type) {
-    this._addLog(message, type, "ERROR");
+  error(message, type, options) {
+    this._addLog(message, type, "SEVERE", "background", options);
   }
 
   /**
    * Log a warning message
    * @param {string} message - Log message
    * @param {string} type - Log type/category
+   * @param {Object} [options] - `{ eventType, payload }`; see _addLog
    */
-  warn(message, type) {
-    this._addLog(message, type, "WARN");
+  warn(message, type, options) {
+    this._addLog(message, type, "WARNING", "background", options);
   }
 
   /**
    * Log an info message
    * @param {string} message - Log message
    * @param {string} type - Log type/category
+   * @param {Object} [options] - `{ eventType, payload }`; see _addLog
    */
-  info(message, type) {
-    this._addLog(message, type, "INFO");
+  info(message, type, options) {
+    this._addLog(message, type, "INFO", "background", options);
   }
 
   /**
-   * Log a debug message (only logged when logLevel is DEBUG)
+   * Log at FINE — emitted only when `logLevel` is FINE, and that is also the
+   * level at which payloads are serialised raw. Use it for the detail that only
+   * matters while actively debugging a session.
+   *
+   * `debug()` is kept as the name because every existing call site uses it.
+   *
    * @param {string} message - Log message
    * @param {string} type - Log type/category
+   * @param {Object} [options] - `{ eventType, payload }`; see _addLog
    */
-  debug(message, type) {
-    this._addLog(message, type, "DEBUG");
+  debug(message, type, options) {
+    this._addLog(message, type, "FINE", "background", options);
+  }
+
+  /** @see debug - alias spelled the way the platform spells the level. */
+  fine(message, type, options) {
+    this._addLog(message, type, "FINE", "background", options);
   }
 
   /**
-   * Handle log message from remote contexts (content/offscreen)
-   * Called by message router when receiving LOG_MESSAGE action
+   * Handle a log relayed from another context (content / offscreen /
+   * interceptor). Called by the message router on LOG_MESSAGE.
+   *
+   * A relayed log appears in two consoles by design: its own context's (from
+   * RemoteLogger) and the service worker's (from `_addLog` below), the latter
+   * labelled with the originating context so a multi-context flow reads in one
+   * place. `payload` survives chrome messaging as a structured clone, so the
+   * level-based redaction applies to it here exactly as it would to a
+   * background log.
+   *
    * @param {string} message - Log message
    * @param {string} type - Log type/category
-   * @param {string} level - Log level ("ERROR" | "WARN" | "INFO" | "DEBUG")
+   * @param {string} level - "SEVERE" | "WARNING" | "INFO" | "FINE"
+   * @param {string} [context] - Originating context
+   * @param {Object} [options] - `{ eventType, payload }` forwarded from that context
    */
-  handleRemoteLog(message, type, level = "INFO") {
-    this._addLog(message, type, level);
+  handleRemoteLog(message, type, level = "INFO", context = "remote", options = undefined) {
+    this._addLog(message, type, level, context, options);
   }
 
   /**
-   * Flush logs to the external API
+   * Flush logs to the external API.
+   *
+   * Calls are SERIALIZED, never skipped. Returning early while another flush is
+   * in flight loses the caller's batch: the periodic flush and the terminal
+   * `clearSessionContext()` regularly overlap, and dropping the terminal one
+   * silently discards the end of a failed session — which is the part that
+   * explains the failure. Each call therefore chains onto the previous one and
+   * flushes whatever is queued when its turn comes.
+   *
+   * @returns {Promise<void>} resolves once THIS call's batch has been attempted
    */
-  async flush() {
-    if (this.logs.length === 0 || this.isFlushing) {
+  flush() {
+    this._flushChain = (this._flushChain || Promise.resolve())
+      .then(() => this._flushOnce())
+      // A rejection must not poison the chain for every later flush.
+      .catch(() => {});
+    return this._flushChain;
+  }
+
+  /**
+   * POST one batch. Only ever called from the `flush()` chain, so it never runs
+   * concurrently with itself.
+   */
+  async _flushOnce() {
+    if (this.logs.length === 0) {
       return;
     }
 
     this.isFlushing = true;
     const batch = this.logs.splice(0, this.logs.length);
     const batchSize = batch.length;
+    // The queue is empty as far as storage is concerned; if the POST fails the
+    // batch goes back and is re-persisted below.
+    this._persistQueue();
 
     try {
       const response = await fetch(LOGGING_ENDPOINTS.DIAGNOSTIC_LOGGING, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: withClientSource({ "Content-Type": "application/json" }),
         body: JSON.stringify({
           logs: batch,
-          source: "browser-extension-sdk",
+          source: getClientSource(),
           deviceId: this.deviceId || "unknown",
         }),
       });
 
       if (!response.ok) {
-        // Re-queue failed logs (prepend to maintain order), respecting max queue size
+        // Re-queue failed logs (prepend to maintain order)
         this.logs.unshift(...batch);
-        if (this.logs.length > this.maxQueueSize) {
-          const dropped = this.logs.length - this.maxQueueSize;
-          this.logs = this.logs.slice(dropped);
-          this.stats.totalLogsDropped += dropped;
-        }
+        this._trimQueue();
+        this._persistQueue();
         if (this.config.consoleEnabled) {
           console.error("[LoggingHub] Failed to flush logs:", response.status);
         }
@@ -381,13 +683,10 @@ class LoggingHub {
         this.stats.flushCount++;
       }
     } catch (error) {
-      // Re-queue failed logs, respecting max queue size
+      // Re-queue failed logs
       this.logs.unshift(...batch);
-      if (this.logs.length > this.maxQueueSize) {
-        const dropped = this.logs.length - this.maxQueueSize;
-        this.logs = this.logs.slice(dropped);
-        this.stats.totalLogsDropped += dropped;
-      }
+      this._trimQueue();
+      this._persistQueue();
       if (this.config.consoleEnabled) {
         console.error("[LoggingHub] Error flushing logs:", error);
       }
@@ -397,7 +696,13 @@ class LoggingHub {
   }
 
   /**
-   * Force immediate flush (useful for cleanup)
+   * Flush now and wait for it.
+   *
+   * Kept as a distinct name because terminal paths read better with it, but
+   * `flush()` is already serialized and awaitable, so this is simply it. The
+   * previous implementation polled `isFlushing` for one second and then called
+   * `flush()` anyway — which no-opped if the in-flight request was still going,
+   * so the terminal batch was dropped exactly when it mattered most.
    */
   async forceFlush() {
     await this.flush();
@@ -412,16 +717,22 @@ class LoggingHub {
       ...this.stats,
       pendingLogs: this.logs.length,
       sessionId: this.sessionContext.sessionId,
+      source: getClientSource(),
     };
   }
 
   /**
-   * Cleanup - stop interval and flush remaining logs
+   * Cleanup - stop the schedule and flush remaining logs
    */
   async destroy() {
     if (this.flushIntervalId) {
       clearInterval(this.flushIntervalId);
       this.flushIntervalId = null;
+    }
+    try {
+      globalThis.chrome?.alarms?.clear?.(LOG_FLUSH_ALARM_NAME);
+    } catch {
+      // alarms may not be available
     }
     await this.flush();
   }
@@ -430,5 +741,5 @@ class LoggingHub {
 // Export singleton instance for background use
 export const loggingHub = new LoggingHub();
 
-// Export class for testing
-export { LoggingHub };
+// Export class and helpers for testing
+export { LoggingHub, truncateLine };

--- a/src/utils/logger/RemoteLogger.js
+++ b/src/utils/logger/RemoteLogger.js
@@ -87,15 +87,18 @@ class RemoteLogger {
     const resolved = normalizeLogLevel(level);
     const fn =
       resolved === "SEVERE" ? console.error : resolved === "WARNING" ? console.warn : console.log;
-    const prefix = `[${resolved}] [${this.source}]${type ? ` [${type}]` : ""} ${message}`;
     const shown =
       payload !== undefined && normalizeLogLevel(this.config.logLevel) !== "FINE"
         ? redact(payload)
         : payload;
+    // Literal format string, `message` passed as an argument — see the note in
+    // log-bridge.js.
+    const format = type ? "[%s] [%s] [%s] %s" : "[%s] [%s] %s";
+    const parts = type ? [resolved, this.source, type, message] : [resolved, this.source, message];
     if (payload !== undefined) {
-      fn(prefix, shown);
+      fn(format, ...parts, shown);
     } else {
-      fn(prefix);
+      fn(format, ...parts);
     }
     return true;
   }

--- a/src/utils/logger/RemoteLogger.js
+++ b/src/utils/logger/RemoteLogger.js
@@ -1,11 +1,32 @@
 /**
- * RemoteLogger - Thin logging client for content scripts and offscreen documents
+ * RemoteLogger - logging client for content scripts and offscreen documents
  *
- * Sends all logs to the background LoggingHub via chrome.runtime.sendMessage.
- * The hub enriches logs with session context before sending to the API.
+ * Two jobs:
+ *  1. Forward every log to the background LoggingHub, which enriches it with
+ *     session context and batches it to the API.
+ *  2. Mirror it to the *local* console of this context, when enabled.
+ *
+ * (2) matters for debugging: without it, an offscreen document's logs only ever
+ * appear in the service worker's console (via the hub), and vanish entirely if
+ * the worker is asleep or the sendMessage fails. Mirroring locally means the
+ * offscreen document's own DevTools console shows offscreen logs, and the page
+ * console shows content-script logs — independent of the worker's state.
+ *
+ * Where to look:
+ *  - service worker  → chrome://extensions → the extension → "service worker"
+ *  - offscreen doc   → chrome://extensions → the extension → "Inspect views:
+ *                      offscreen/offscreen.html"
+ *  - content script  → the provider tab's own DevTools console
  */
 
 import { MESSAGE_ACTIONS, MESSAGE_SOURCES } from "../constants";
+import {
+  DEFAULT_LOG_CONFIG,
+  LOG_CONFIG_STORAGE_KEY,
+  LOG_LEVEL,
+  normalizeLogLevel,
+} from "./constants";
+import { redact } from "./redact.js";
 
 class RemoteLogger {
   /**
@@ -14,37 +35,143 @@ class RemoteLogger {
    */
   constructor(source) {
     this.source = source;
+
+    // Start from the defaults so logs emitted before storage resolves are not
+    // silently dropped, then reconcile with the stored config.
+    this.config = { ...DEFAULT_LOG_CONFIG };
+    this._loadConfig();
+    this._watchConfig();
+  }
+
+  async _loadConfig() {
+    try {
+      const stored = await chrome.storage?.local?.get(LOG_CONFIG_STORAGE_KEY);
+      if (stored?.[LOG_CONFIG_STORAGE_KEY]) {
+        this.config = { ...this.config, ...stored[LOG_CONFIG_STORAGE_KEY] };
+      }
+    } catch {
+      // chrome.storage may be unavailable in this context; keep defaults.
+    }
+  }
+
+  _watchConfig() {
+    try {
+      chrome.storage?.onChanged?.addListener((changes, area) => {
+        if (area === "local" && changes[LOG_CONFIG_STORAGE_KEY]?.newValue) {
+          this.config = { ...this.config, ...changes[LOG_CONFIG_STORAGE_KEY].newValue };
+        }
+      });
+    } catch {
+      // Storage may not be available.
+    }
+  }
+
+  _shouldLog(level) {
+    const threshold = LOG_LEVEL[normalizeLogLevel(this.config.logLevel)] || LOG_LEVEL.INFO;
+    return (LOG_LEVEL[normalizeLogLevel(level)] || LOG_LEVEL.INFO) <= threshold;
   }
 
   /**
-   * Send log to background hub
+   * Mirror to this context's console. Returns whether it actually printed, so
+   * the send-failure path knows if the line has been surfaced anywhere.
+   *
+   * The payload is redacted here unless the level is FINE, matching the hub:
+   * one threshold decides both what is emitted and whether values are raw, so
+   * enabling this console can never reveal more than the endpoint holds. It is
+   * still passed as a live object (a redacted copy at INFO) so devtools renders
+   * an inspectable tree.
+   * @returns {boolean}
+   */
+  _console(message, type, level, payload) {
+    if (!this.config.consoleEnabled || !this._shouldLog(level)) return false;
+    const resolved = normalizeLogLevel(level);
+    const fn =
+      resolved === "SEVERE" ? console.error : resolved === "WARNING" ? console.warn : console.log;
+    const prefix = `[${resolved}] [${this.source}]${type ? ` [${type}]` : ""} ${message}`;
+    const shown =
+      payload !== undefined && normalizeLogLevel(this.config.logLevel) !== "FINE"
+        ? redact(payload)
+        : payload;
+    if (payload !== undefined) {
+      fn(prefix, shown);
+    } else {
+      fn(prefix);
+    }
+    return true;
+  }
+
+  /**
+   * Send log to background hub, and mirror to this context's console.
+   *
+   * Forwarding is unconditional — the hub owns the remote threshold. Filtering
+   * here on the console threshold would mean turning the console down also
+   * shrank the diagnostic dump, which is the opposite of what it should do.
+   *
    * @param {string} message - Log message
    * @param {string} type - Log type/category
    * @param {string} level - Log level ("ERROR" | "WARN" | "INFO" | "DEBUG")
+   * @param {Object} [options] - `{ eventType, payload }`. `payload` is sent as
+   *   an object (chrome messaging structured-clones it) so the hub can redact it
+   *   for the endpoint while both consoles show the real values.
    */
-  _sendLog(message, type, level = "INFO") {
+  _sendLog(message, type, level = "INFO", options = undefined) {
+    const { payload } = options || {};
+    const mirrored = this._console(message, type, level, payload);
+
+    // Last resort when the hub is unreachable: surface the line locally, but
+    // only if the mirror above did not already print it.
+    const fallback = () => {
+      if (!mirrored) {
+        console.log(`[${level}] [${this.source}]${type ? ` [${type}]` : ""} ${message}`);
+      }
+    };
+
     try {
-      chrome.runtime
-        .sendMessage({
-          action: MESSAGE_ACTIONS.LOG_MESSAGE,
-          source:
-            this.source === "content" ? MESSAGE_SOURCES.CONTENT_SCRIPT : MESSAGE_SOURCES.OFFSCREEN,
-          target: MESSAGE_SOURCES.BACKGROUND,
-          data: {
-            message,
-            type,
-            source: this.source,
-            level,
-          },
-        })
-        .catch(() => {
-          // Background may be unavailable (service worker inactive)
-          // Fallback to console
-          console.log(`[${this.source}]`, message);
-        });
+      const sending = chrome.runtime.sendMessage({
+        action: MESSAGE_ACTIONS.LOG_MESSAGE,
+        source:
+          this.source === "content" ? MESSAGE_SOURCES.CONTENT_SCRIPT : MESSAGE_SOURCES.OFFSCREEN,
+        target: MESSAGE_SOURCES.BACKGROUND,
+        data: {
+          message,
+          type,
+          source: this.source,
+          level,
+          options,
+        },
+      });
+      // MV2/Firefox callback-style sendMessage returns undefined, not a promise.
+      if (sending?.catch) sending.catch(fallback);
     } catch {
-      // chrome.runtime may not be available
-      console.log(`[${this.source}]`, message);
+      fallback();
+    }
+  }
+
+  /**
+   * Relay a log that originated in another context, preserving its own
+   * identity instead of re-labelling it as this logger's source.
+   *
+   * Used by the content script for MAIN-world logs arriving over the
+   * RECLAIM_LOG bridge: those come from "interceptor"/"injection", and
+   * attributing them to "content" would hide where interception actually
+   * failed.
+   *
+   * @param {string} message - Log message
+   * @param {string} type - Log type/category
+   * @param {string} level - Log level
+   * @param {string} context - Originating context ("interceptor" | "injection")
+   */
+  relay(message, type, level = "INFO", context = "page", options = undefined) {
+    try {
+      const sending = chrome.runtime.sendMessage({
+        action: MESSAGE_ACTIONS.LOG_MESSAGE,
+        source: MESSAGE_SOURCES.CONTENT_SCRIPT,
+        target: MESSAGE_SOURCES.BACKGROUND,
+        data: { message, type, source: context, level, options },
+      });
+      if (sending?.catch) sending.catch(() => {});
+    } catch {
+      // Background unreachable; the page console already showed this line.
     }
   }
 
@@ -52,9 +179,10 @@ class RemoteLogger {
    * Log an error message (highest severity - always logged)
    * @param {string} message - Log message
    * @param {string} type - Log type/category
+   * @param {Object} [options] - `{ eventType, payload }`
    */
-  error(message, type) {
-    this._sendLog(message, type, "ERROR");
+  error(message, type, options) {
+    this._sendLog(message, type, "SEVERE", options);
   }
 
   /**
@@ -62,8 +190,8 @@ class RemoteLogger {
    * @param {string} message - Log message
    * @param {string} type - Log type/category
    */
-  warn(message, type) {
-    this._sendLog(message, type, "WARN");
+  warn(message, type, options) {
+    this._sendLog(message, type, "WARNING", options);
   }
 
   /**
@@ -71,17 +199,23 @@ class RemoteLogger {
    * @param {string} message - Log message
    * @param {string} type - Log type/category
    */
-  info(message, type) {
-    this._sendLog(message, type, "INFO");
+  info(message, type, options) {
+    this._sendLog(message, type, "INFO", options);
   }
 
   /**
-   * Log a debug message (only logged when logLevel is DEBUG)
+   * Log at FINE — emitted only when `logLevel` is FINE, which is also the level
+   * at which payload values are kept raw.
    * @param {string} message - Log message
    * @param {string} type - Log type/category
    */
-  debug(message, type) {
-    this._sendLog(message, type, "DEBUG");
+  debug(message, type, options) {
+    this._sendLog(message, type, "FINE", options);
+  }
+
+  /** @see debug - alias spelled the way the platform spells the level. */
+  fine(message, type, options) {
+    this._sendLog(message, type, "FINE", options);
   }
 }
 

--- a/src/utils/logger/client-source.js
+++ b/src/utils/logger/client-source.js
@@ -1,0 +1,184 @@
+/**
+ * Client source — the SDK's self-identification string.
+ *
+ * One string, two consumers:
+ *  - the `reclaim-api-client` header on every request the SDK makes
+ *  - the `source` field on every log batch AND every individual log entry
+ *
+ * The grammar mirrors the InApp SDK's `getClientSource()`
+ * (reclaim-inapp-sdk/lib/src/services/source/source.dart):
+ *
+ *     <sdk-name> sdk/v<sdk-version> (<platform>,<consumer>/v<consumer-version>)
+ *
+ *   InApp: verifier-app sdk/v0.43.0 operator/v3.5.0 (ios,org.reclaimprotocol.app/v1.50.1+816)
+ *   Ours:  browser-extension-sdk sdk/v0.4.2 (chrome/141,ldbfjimhpnpkeanmnfkkbdhllcmjjhpp/v1.0.0)
+ *
+ * Two deliberate differences from InApp:
+ *  - No `operator/` clause. The extension has no TEE operator package to report;
+ *    emitting `operator/unknown` would be noise, not information.
+ *  - InApp's builder is async (`PackageInfo.fromPlatform()` is a platform
+ *    channel). Every input here is synchronous — `chrome.runtime.getManifest()`
+ *    and `navigator.userAgentData.brands` both return immediately — so this is a
+ *    plain memoized function. That matters: an async source would leave the
+ *    earliest logs of a session, the ones that explain a startup failure,
+ *    stamped with a placeholder.
+ *
+ * The team's identification rule is a substring check, and every string this
+ * module can produce contains `browser-extension-sdk` — including the
+ * degraded-environment fallbacks.
+ */
+
+export const SDK_NAME = "browser-extension-sdk";
+
+// DefinePlugin substitutes this in all three webpack configs. The `typeof`
+// guard keeps the module importable under Node for tests, where it is absent.
+// eslint-disable-next-line no-undef
+const SDK_VERSION = typeof __SDK_VERSION__ !== "undefined" ? __SDK_VERSION__ : "unknown";
+
+/** Header name InApp/Verifier already send on every request. */
+export const CLIENT_SOURCE_HEADER = "reclaim-api-client";
+
+// Ordered longest-alias-first: Edge and Opera user agents also contain
+// "Chrome/", and Safari's contains "Version/" before "Safari/".
+const UA_PATTERNS = [
+  [/\bEdg(?:e|A|iOS)?\/(\d+)/, "edge"],
+  [/\bOPR\/(\d+)/, "opera"],
+  [/\bFirefox\/(\d+)/, "firefox"],
+  [/\bChrome\/(\d+)/, "chrome"],
+  [/\bVersion\/(\d+)[^ ]* Safari\//, "safari"],
+];
+
+/**
+ * Sanitize an atomic component — a brand name, a version, an extension ID.
+ *
+ * The grammar's separators are space, comma, slash and parens, so none of them
+ * may appear inside a component. Use `field()` instead for a value that is
+ * already `name/version` and legitimately contains a slash.
+ */
+function token(value, fallback = "unknown") {
+  const cleaned = String(value ?? "")
+    .replace(/[\s(),/]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned || fallback;
+}
+
+/**
+ * Sanitize a composed `name/version` value. Same as `token()` but keeps the
+ * slash, which is a separator *within* the field rather than between fields.
+ */
+function field(value, fallback = "unknown") {
+  const cleaned = String(value ?? "")
+    .replace(/[\s(),]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned || fallback;
+}
+
+/**
+ * Browser name and major version, e.g. "chrome/141".
+ *
+ * `navigator.userAgentData` is available in service workers and is preferred
+ * because Chrome freezes the legacy UA string. `brands` is sync; only
+ * `getHighEntropyValues()` is async, and we don't need it.
+ */
+function detectPlatform() {
+  const nav = typeof navigator !== "undefined" ? navigator : undefined;
+  if (!nav) return "unknown";
+
+  const brands = nav.userAgentData?.brands;
+  if (Array.isArray(brands)) {
+    // Chrome pads `brands` with a deliberately garbled entry ("Not.A/Brand",
+    // ";Not A Brand", …) to break naive UA parsing. Skip it.
+    const brand = brands.find((b) => b?.brand && !/not[^a-z]*a[^a-z]*brand/i.test(b.brand));
+    if (brand) return `${token(brand.brand.toLowerCase())}/${token(brand.version)}`;
+  }
+
+  const ua = nav.userAgent || "";
+  for (const [pattern, name] of UA_PATTERNS) {
+    const match = pattern.exec(ua);
+    if (match) return `${name}/${match[1]}`;
+  }
+  return "unknown";
+}
+
+/**
+ * The consumer this SDK is embedded in.
+ *
+ * In an extension context that is the host extension: its ID is the closest
+ * analogue of InApp's package identifier — stable, unique per published
+ * extension, and free of characters that would break the grammar. The manifest
+ * `name` is not used: it is user-facing, localizable, and full of spaces.
+ *
+ * In web-page mode there is no manifest, so there is nothing to report; the
+ * clause degrades to "web" rather than inventing an identity.
+ */
+function detectConsumer() {
+  try {
+    const manifest = globalThis.chrome?.runtime?.getManifest?.();
+    if (manifest) {
+      const id = token(globalThis.chrome?.runtime?.id, "unpacked");
+      return `${id}/v${token(manifest.version)}`;
+    }
+  } catch {
+    // Not an extension context, or the API is unavailable.
+  }
+  return "web";
+}
+
+/**
+ * Assemble the string. Pure and exported so the grammar itself is testable
+ * without a browser.
+ *
+ * @param {Object} parts
+ * @param {string} parts.sdkVersion - bare version, no leading "v"
+ * @param {string} parts.platform - e.g. "chrome/141"
+ * @param {string} parts.consumer - e.g. "<ext-id>/v1.0.0" or "web"
+ * @returns {string}
+ */
+export function buildClientSource({ sdkVersion, platform, consumer }) {
+  return `${SDK_NAME} sdk/v${token(sdkVersion)} (${field(platform)},${field(consumer)})`;
+}
+
+let cached = null;
+
+/**
+ * Memoized client source for this context.
+ *
+ * Cached per JS realm, so a service-worker restart rebuilds it — which is
+ * correct, since a browser update between restarts should be reflected.
+ *
+ * @returns {string}
+ */
+export function getClientSource() {
+  if (cached === null) {
+    try {
+      cached = buildClientSource({
+        sdkVersion: SDK_VERSION,
+        platform: detectPlatform(),
+        consumer: detectConsumer(),
+      });
+    } catch {
+      // Never let identification break a request or a log.
+      cached = `${SDK_NAME} sdk/v${token(SDK_VERSION)} (unknown,unknown)`;
+    }
+  }
+  return cached;
+}
+
+/** Test seam — drops the memoized value. */
+export function resetClientSourceCache() {
+  cached = null;
+}
+
+/**
+ * Merge the `reclaim-api-client` header into a headers object.
+ *
+ * Every outbound request from the SDK goes through this so extension traffic is
+ * attributable server-side. Note this is identification only: per the team's
+ * guideline the extension contributes no device information to analytics.
+ *
+ * @param {Object} [headers]
+ * @returns {Object}
+ */
+export function withClientSource(headers = {}) {
+  return { ...headers, [CLIENT_SOURCE_HEADER]: getClientSource() };
+}

--- a/src/utils/logger/client-source.test.js
+++ b/src/utils/logger/client-source.test.js
@@ -1,0 +1,118 @@
+/**
+ * The client source string is a wire contract in two directions: the
+ * `reclaim-api-client` header the backends read, and the `source` field the
+ * logs pipeline groups by. The team's rule for identifying which SDK produced a
+ * session is a substring check for `browser-extension-sdk`, so these tests
+ * pin the grammar and, above all, that no code path can produce a string
+ * missing that marker.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import {
+  SDK_NAME,
+  CLIENT_SOURCE_HEADER,
+  buildClientSource,
+  getClientSource,
+  resetClientSourceCache,
+  withClientSource,
+} from "./client-source.js";
+
+describe("buildClientSource", () => {
+  it("mirrors the InApp grammar", () => {
+    assert.equal(
+      buildClientSource({
+        sdkVersion: "0.4.2",
+        platform: "chrome/141",
+        consumer: "ldbfjimhpnpkeanmnfkkbdhllcmjjhpp/v1.0.0",
+      }),
+      "browser-extension-sdk sdk/v0.4.2 (chrome/141,ldbfjimhpnpkeanmnfkkbdhllcmjjhpp/v1.0.0)",
+    );
+  });
+
+  it("reports web-page mode as (…,web) rather than inventing a consumer", () => {
+    const source = buildClientSource({
+      sdkVersion: "0.4.2",
+      platform: "firefox/128",
+      consumer: "web",
+    });
+    assert.equal(source, "browser-extension-sdk sdk/v0.4.2 (firefox/128,web)");
+  });
+
+  it("strips separators out of tokens so the string stays parseable", () => {
+    // A manifest name or brand containing spaces, commas or parens would
+    // otherwise produce a string that cannot be split back apart.
+    const source = buildClientSource({
+      sdkVersion: "1.0.0-beta 1",
+      platform: "Some Browser (Beta)/1",
+      consumer: "my ext, inc/v2",
+    });
+    assert.equal(source.match(/\(/g).length, 1, "exactly one opening paren");
+    assert.equal(source.match(/,/g).length, 1, "exactly one comma separator");
+    assert.ok(!/\s\)/.test(source));
+  });
+
+  it("substitutes a placeholder for empty tokens instead of collapsing", () => {
+    const source = buildClientSource({ sdkVersion: "1.0.0", platform: "", consumer: "" });
+    assert.equal(source, "browser-extension-sdk sdk/v1.0.0 (unknown,unknown)");
+  });
+});
+
+describe("getClientSource", () => {
+  it("always contains the SDK marker the team's check looks for", () => {
+    resetClientSourceCache();
+    const source = getClientSource();
+    assert.ok(
+      source.includes("browser-extension-sdk"),
+      `expected the marker in ${JSON.stringify(source)}`,
+    );
+    assert.equal(SDK_NAME, "browser-extension-sdk");
+  });
+
+  it("is memoized", () => {
+    resetClientSourceCache();
+    assert.equal(getClientSource(), getClientSource());
+  });
+
+  it("survives a hostile environment without throwing", () => {
+    // A page can replace navigator getters. Identification must degrade, never
+    // break the request it is attached to.
+    resetClientSourceCache();
+    const original = globalThis.navigator;
+    try {
+      Object.defineProperty(globalThis, "navigator", {
+        get() {
+          throw new Error("nope");
+        },
+        configurable: true,
+      });
+      const source = getClientSource();
+      assert.ok(source.includes("browser-extension-sdk"));
+    } finally {
+      if (original === undefined) {
+        delete globalThis.navigator;
+      } else {
+        Object.defineProperty(globalThis, "navigator", {
+          value: original,
+          configurable: true,
+          writable: true,
+        });
+      }
+      resetClientSourceCache();
+    }
+  });
+});
+
+describe("withClientSource", () => {
+  it("adds the header InApp and Verifier already send", () => {
+    assert.equal(CLIENT_SOURCE_HEADER, "reclaim-api-client");
+    const headers = withClientSource({ "Content-Type": "application/json" });
+    assert.equal(headers["Content-Type"], "application/json");
+    assert.ok(headers["reclaim-api-client"].includes("browser-extension-sdk"));
+  });
+
+  it("works with no argument", () => {
+    assert.ok(withClientSource()["reclaim-api-client"]);
+  });
+});

--- a/src/utils/logger/constants.js
+++ b/src/utils/logger/constants.js
@@ -10,58 +10,191 @@ export const LOG_SOURCES = {
   INJECTION: "injection",
 };
 
+/**
+ * Canonical event taxonomy, reconciled against the InApp SDK's `LogEventType`
+ * (reclaim-inapp-sdk/lib/src/logging/event_type.dart).
+ *
+ * A name that exists upstream MUST be spelled the same way here — the whole
+ * point is that one Grafana query works across SDKs. Names that used to differ
+ * were renamed to InApp's spelling:
+ *
+ *   RESPONSE_MATCH_FAILED        → NO_RESPONSE_MATCH_WARNING
+ *   CLAIM_CREATION_SUCCESS       → PROOF_GENERATED
+ *   CLAIM_CREATION_FAILED        → PROOF_GENERATION_FAILED_EXCEPTION
+ *   PROOF_GENERATION_ABORTED     → CLAIM_CREATION_CANCELLED_EXCEPTION
+ *   VERIFICATION_FLOW_FAILED     → RECLAIM_EXCEPTION
+ *   FILTERED_REQUEST_FOUND       → dropped; it duplicated REQUEST_MATCHED
+ *   SUBMITTING_PROOF_TO_CALLBACK_URL{,_SUCCESS,_FAILED}
+ *                                → SUBMITTING_PROOF / PROOF_SUBMITTED /
+ *                                  PROOF_SUBMISSION_FAILED (the callback URL is
+ *                                  where submission goes, not a distinct event)
+ *
+ * `IS_RECLAIM_EXTENSION_SDK` intentionally keeps its own name — it is the
+ * per-SDK identity marker, InApp's equivalents being IS_RECLAIM_INAPPSDK and
+ * IS_RECLAIM_VERIFIER.
+ *
+ * Before adding a name, check event_type.dart for one that already means this.
+ */
 export const EVENT_TYPES = {
+  // --- Session and flow lifecycle ---
   IS_RECLAIM_EXTENSION_SDK: "IS_RECLAIM_EXTENSION_SDK",
   VERIFICATION_FLOW_STARTED: "VERIFICATION_FLOW_STARTED",
-  RECLAIM_VERIFICATION_DISMISSED: "RECLAIM_VERIFICATION_DISMISSED",
-  RECLAIM_VERIFICATION_PROVIDER_LOAD_EXCEPTION: "RECLAIM_VERIFICATION_PROVIDER_LOAD_EXCEPTION",
+  USER_STARTED_VERIFICATION: "USER_STARTED_VERIFICATION",
+  FETCHED_PROVIDERS: "FETCHED_PROVIDERS",
+  LOADING_INITIAL_URL: "LOADING_INITIAL_URL",
+  WEB_PAGE_READY: "WEB_PAGE_READY",
+  PAGE_LOADING_STARTED: "PAGE_LOADING_STARTED",
+  PAGE_LOADING_STOPPED: "PAGE_LOADING_STOPPED",
+
+  // --- Request interception and matching ---
+  REQUEST_INTERCEPTED: "REQUEST_INTERCEPTED",
   REQUEST_MATCHED: "REQUEST_MATCHED",
-  RESPONSE_MATCH_FAILED: "RESPONSE_MATCH_FAILED",
+  NO_RESPONSE_MATCH_WARNING: "NO_RESPONSE_MATCH_WARNING",
   X_PATH_MATCH_REQUIREMENT_FAILED: "X_PATH_MATCH_REQUIREMENT_FAILED",
   JSON_PATH_MATCH_REQUIREMENT_FAILED: "JSON_PATH_MATCH_REQUIREMENT_FAILED",
   REGEX_MATCH_REQUIREMENT_FAILED: "REGEX_MATCH_REQUIREMENT_FAILED",
-  FILTERED_REQUEST_FOUND: "FILTERED_REQUEST_FOUND",
   FILTER_REQUEST_ERROR: "FILTER_REQUEST_ERROR",
+
+  // --- Claim creation ---
+  PROVIDER_SCRIPT_REQUESTED_CLAIM: "PROVIDER_SCRIPT_REQUESTED_CLAIM",
   STARTING_CLAIM_CREATION: "STARTING_CLAIM_CREATION",
-  CLAIM_CREATION_STARTED: "CLAIM_CREATION_STARTED",
-  CLAIM_CREATION_SUCCESS: "CLAIM_CREATION_SUCCESS",
-  CLAIM_CREATION_FAILED: "CLAIM_CREATION_FAILED",
+  PREPARING_CLAIM: "PREPARING_CLAIM",
+  VALIDATING_CLAIM_PARAMETERS: "VALIDATING_CLAIM_PARAMETERS",
+  NO_PARAMETERS_FOUND: "NO_PARAMETERS_FOUND",
   CLAIM_PARAMETER_VALIDATION_FAILED_EXCEPTION: "CLAIM_PARAMETER_VALIDATION_FAILED_EXCEPTION",
+  CLAIM_CREATION_STARTED: "CLAIM_CREATION_STARTED",
+  CLAIM_CREATION_CANCELLED_EXCEPTION: "CLAIM_CREATION_CANCELLED_EXCEPTION",
+  CLAIM_CREATION_TIMED_OUT_EXCEPTION: "CLAIM_CREATION_TIMED_OUT_EXCEPTION",
+
+  // --- Proof generation ---
+  PROOF_GENERATION_STARTED: "PROOF_GENERATION_STARTED",
+  PROOF_GENERATED: "PROOF_GENERATED",
+  PROOF_GENERATION_SUCCESS: "PROOF_GENERATION_SUCCESS",
+  PROOF_GENERATION_FAILED: "PROOF_GENERATION_FAILED",
+  PROOF_GENERATION_FAILED_EXCEPTION: "PROOF_GENERATION_FAILED_EXCEPTION",
+  ATTESTOR_NOT_RESPONDING: "ATTESTOR_NOT_RESPONDING",
+  RESULT_RECEIVED: "RESULT_RECEIVED",
+
+  // --- Submission ---
+  SUBMITTING_PROOF: "SUBMITTING_PROOF",
+  PROOF_SUBMITTED: "PROOF_SUBMITTED",
+  PROOF_SUBMISSION_FAILED: "PROOF_SUBMISSION_FAILED",
+
+  // --- Terminal states and exceptions ---
+  RECLAIM_VERIFICATION_DISMISSED: "RECLAIM_VERIFICATION_DISMISSED",
+  RECLAIM_VERIFICATION_CANCELLED_EXCEPTION: "RECLAIM_VERIFICATION_CANCELLED_EXCEPTION",
+  RECLAIM_VERIFICATION_PROVIDER_LOAD_EXCEPTION: "RECLAIM_VERIFICATION_PROVIDER_LOAD_EXCEPTION",
+  RECLAIM_VERIFICATION_NO_ACTIVITY_DETECTED_EXCEPTION:
+    "RECLAIM_VERIFICATION_NO_ACTIVITY_DETECTED_EXCEPTION",
+  RECLAIM_INIT_SESSION_EXCEPTION: "RECLAIM_INIT_SESSION_EXCEPTION",
+  INVALID_REQUEST_RECLAIM_EXCEPTION: "INVALID_REQUEST_RECLAIM_EXCEPTION",
+  RECLAIM_EXCEPTION: "RECLAIM_EXCEPTION",
+  UNKNOWN: "UNKNOWN",
+
+  // --- Extension-only: no InApp analogue, because the mechanism doesn't exist
+  // there (MV3 offscreen documents, browser tabs, the injected popup).
   OFFSCREEN_DOCUMENT_READY: "OFFSCREEN_DOCUMENT_READY",
   OFFSCREEN_DOCUMENT_NOT_READY_EXCEPTION: "OFFSCREEN_DOCUMENT_NOT_READY_EXCEPTION",
-  PROOF_GENERATION_STARTED: "PROOF_GENERATION_STARTED",
-  PROOF_GENERATION_SUCCESS: "PROOF_GENERATION_SUCCESS",
-  PROOF_GENERATION_ABORTED: "PROOF_GENERATION_ABORTED",
-  PROOF_GENERATION_FAILED: "PROOF_GENERATION_FAILED",
-  RESULT_RECEIVED: "RESULT_RECEIVED",
-  SUBMITTING_PROOF: "SUBMITTING_PROOF",
-  SUBMITTING_PROOF_TO_CALLBACK_URL: "SUBMITTING_PROOF_TO_CALLBACK_URL",
-  SUBMITTING_PROOF_TO_CALLBACK_URL_SUCCESS: "SUBMITTING_PROOF_TO_CALLBACK_URL_SUCCESS",
-  SUBMITTING_PROOF_TO_CALLBACK_URL_FAILED: "SUBMITTING_PROOF_TO_CALLBACK_URL_FAILED",
-  PROOF_SUBMISSION_FAILED: "PROOF_SUBMISSION_FAILED",
-  PROOF_SUBMITTED: "PROOF_SUBMITTED",
-  VERIFICATION_FLOW_FAILED: "VERIFICATION_FLOW_FAILED",
   TAB_NOT_MANAGED_BY_EXTENSION_EXCEPTION: "TAB_NOT_MANAGED_BY_EXTENSION_EXCEPTION",
   INJECTION_SCRIPT_SET_IN_LOCAL_STORAGE_FAILED: "INJECTION_SCRIPT_SET_IN_LOCAL_STORAGE_FAILED",
   VERIFICATION_POPUP_ERROR: "VERIFICATION_POPUP_ERROR",
   UPDATE_SESSION_STATUS_ERROR: "UPDATE_SESSION_STATUS_ERROR",
 };
 
-// Log levels for filtering (lower number = higher severity)
-// ERROR: Only .error() calls
-// WARN: .error() + .warn() calls
-// INFO: .error() + .warn() + .info() calls
-// DEBUG: All logs including .debug() calls
+/**
+ * Log levels (lower number = higher severity), spelled the way the rest of the
+ * platform spells them.
+ *
+ * The names are NOT arbitrary. The InApp SDK, the Portal and the log viewer all
+ * speak Java-style levels, and the logs API only accepts
+ * `fine | config | info | warning | severe` when filtering by severity. The
+ * extension used to emit ERROR/WARN/DEBUG, which meant its lines could not be
+ * filtered by severity alongside the other SDKs' at all.
+ *
+ * There are only two levels a caller has to think about:
+ *
+ *   INFO — the default. Everything about the session, with values REDACTED.
+ *   FINE — opt-in. The same information with values RAW.
+ *
+ * WARNING and SEVERE are more severe than INFO, so they are always visible at
+ * the default threshold; they exist so a query can isolate failures, not to
+ * hide anything.
+ */
 export const LOG_LEVEL = {
-  ERROR: 1,
-  WARN: 2,
+  SEVERE: 1,
+  WARNING: 2,
   INFO: 3,
-  DEBUG: 4,
+  FINE: 4,
 };
 
+/**
+ * Pre-rename spellings, still accepted from consumers and from older callers.
+ * `DEBUG` maps to FINE, which is the level that now carries raw values.
+ */
+const LOG_LEVEL_ALIASES = {
+  ERROR: "SEVERE",
+  WARN: "WARNING",
+  WARNING: "WARNING",
+  DEBUG: "FINE",
+  TRACE: "FINE",
+  FINER: "FINE",
+  FINEST: "FINE",
+  CONFIG: "INFO",
+};
+
+/**
+ * Resolve any accepted spelling to a canonical level name.
+ *
+ * @param {string} level
+ * @param {string} [fallback] - used when `level` is absent or unrecognised
+ * @returns {"SEVERE"|"WARNING"|"INFO"|"FINE"}
+ */
+export function normalizeLogLevel(level, fallback = "INFO") {
+  if (!level) return fallback;
+  const upper = String(level).toUpperCase();
+  if (LOG_LEVEL[upper] !== undefined) return upper;
+  return LOG_LEVEL_ALIASES[upper] || fallback;
+}
+
 export const DEFAULT_LOG_CONFIG = {
-  logLevel: "DEBUG", // "ERROR" | "WARN" | "INFO" | "DEBUG" - filter threshold
-  consoleEnabled: false, // Enable/disable console logging
+  // The ONLY threshold. It governs the console and the remote endpoint
+  // together, so both destinations always hold the same text — there is no
+  // longer a level at which the console shows something the endpoint does not.
+  //
+  //   INFO — redacted. No response bodies, no extracted values, no claim
+  //          payload, no credentials. Safe as a default for an extension that
+  //          ships to end users.
+  //   FINE — raw. Response bodies, real parameter values, the full claim
+  //          (owner private key, session cookies) and the full proof. Sent to
+  //          the endpoint as well, which is the point: it is how a client's
+  //          failing session gets diagnosed remotely, with their permission.
+  //
+  // FINE is never a default and should be set per verification rather than
+  // left on a device:
+  //   reclaimExtensionSDK.init(..., { logConfig: { logLevel: "FINE" } })
+  logLevel: "INFO", // "SEVERE" | "WARNING" | "INFO" | "FINE"
+
+  // Off by default, and independent of the level. A consumer extension ships
+  // to end users and the content-script console is the *provider tab's*
+  // console — a verification would otherwise narrate itself in the user's own
+  // devtools. Diagnostics still reach the endpoint; this only mirrors locally.
+  //
+  // Turn it on while developing:
+  //   reclaimExtensionSDK.setLogConfig({ consoleEnabled: true, logLevel: "FINE" })
+  // then read the service worker (chrome://extensions → "service worker"), the
+  // offscreen document (same page → "Inspect views: offscreen/offscreen.html"),
+  // and the provider tab's own console.
+  consoleEnabled: false,
 };
 
 export const LOG_CONFIG_STORAGE_KEY = "reclaim_extension_sdk_log_config";
+
+// Where the pending log queue is parked so it survives a service-worker
+// restart. `chrome.storage.session` is the right store: it is cleared when the
+// browser closes, so logs never outlive the browsing session that produced
+// them, but it does survive the MV3 worker being torn down mid-flow.
+export const LOG_QUEUE_STORAGE_KEY = "reclaim_extension_sdk_log_queue";
+
+// Name of the chrome.alarms alarm used for the periodic flush, when the
+// `alarms` permission is present. See LoggingHub._startFlushSchedule.
+export const LOG_FLUSH_ALARM_NAME = "reclaim-log-flush";

--- a/src/utils/logger/logging-hub.test.js
+++ b/src/utils/logger/logging-hub.test.js
@@ -196,7 +196,9 @@ describe("redaction follows the level, not the destination", () => {
     }
 
     assert.equal(captured.length, 1);
-    const shown = captured[0][1];
+    // Last argument: the line is emitted as a literal format string plus its
+    // substitutions, so the payload is no longer at index 1.
+    const shown = captured[0].at(-1);
     // Still an object, so devtools renders a tree — but a redacted copy, and
     // emphatically not the caller's live object.
     assert.notEqual(shown, TEMPLATE, "the console must not get the live object at INFO");
@@ -220,7 +222,7 @@ describe("redaction follows the level, not the destination", () => {
     const line = hub.logs[0].logLine;
     assert.ok(line.includes("0xsignaturevalue"), "FINE ships the real value remotely");
     assert.ok(line.includes("1234567890"));
-    assert.equal(captured[0][1], TEMPLATE, "the console gets the live object at FINE");
+    assert.equal(captured[0].at(-1), TEMPLATE, "the console gets the live object at FINE");
   });
 
   it("caps the redacted line, and allows a much longer raw one", () => {

--- a/src/utils/logger/logging-hub.test.js
+++ b/src/utils/logger/logging-hub.test.js
@@ -1,0 +1,718 @@
+/**
+ * The user-visible contract this file protects:
+ *
+ *  1. ONE threshold, `logLevel`, governs the console and the endpoint together,
+ *     and it decides redaction: INFO blanks values, FINE keeps them raw. A stock
+ *     install therefore sends no user data anywhere.
+ *  2. Levels are spelled the way the rest of the platform spells them
+ *     (SEVERE/WARNING/INFO/FINE), so extension sessions filter alongside the
+ *     InApp SDK's; the older ERROR/WARN/DEBUG spellings still resolve.
+ *  3. Every entry carries the SDK identity and the session identifiers, so a
+ *     single line lifted out of Loki is attributable.
+ *  4. A repeat inside the dedupe window is counted, not discarded.
+ *  5. One giant line cannot blow up the batch that carries every other log.
+ *
+ * The hub talks to `chrome.*` and `fetch`, both stubbed here. It is also a
+ * singleton claimed at module import, so this file drives that one instance;
+ * node:test gives each file its own process, so there is no cross-file bleed.
+ */
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert";
+
+import { EVENT_TYPES, DEFAULT_LOG_CONFIG } from "./constants.js";
+
+const storage = { local: new Map(), session: new Map() };
+const sent = [];
+
+function installChromeStub() {
+  const area = (map) => ({
+    get: async (key) => {
+      const keys = Array.isArray(key) ? key : [key];
+      const out = {};
+      for (const k of keys) if (map.has(k)) out[k] = map.get(k);
+      return out;
+    },
+    set: async (obj) => {
+      for (const [k, v] of Object.entries(obj)) map.set(k, v);
+    },
+    remove: async (key) => {
+      map.delete(key);
+    },
+  });
+
+  globalThis.chrome = {
+    storage: {
+      local: area(storage.local),
+      session: area(storage.session),
+      onChanged: { addListener() {} },
+    },
+    runtime: { onSuspend: { addListener() {} }, getManifest: () => ({ version: "9.9.9" }) },
+    // No chrome.alarms: exercises the setInterval fallback path.
+  };
+
+  globalThis.fetch = async (_url, options) => {
+    sent.push(JSON.parse(options.body));
+    return { ok: true, status: 200 };
+  };
+}
+
+let hub;
+let truncateLine;
+
+before(async () => {
+  installChromeStub();
+  const mod = await import("./LoggingHub.js");
+  hub = mod.loggingHub;
+  truncateLine = mod.truncateLine;
+
+  // Force the deferred init to run now (it fires on first use), then neutralise
+  // the timers it started so they cannot drain the queue mid-assertion or hold
+  // the test process open. The stub has no chrome.alarms, so this also confirms
+  // the setInterval fallback is the path taken without it.
+  hub.flushIntervalMs = 60_000;
+  hub._addLog("bootstrap", "test.bootstrap", "DEBUG");
+  await hub.ready;
+  assert.ok(hub.flushIntervalId, "expected the setInterval fallback with no chrome.alarms");
+  hub.flushIntervalId.unref?.();
+});
+
+beforeEach(() => {
+  hub.logs = [];
+  sent.length = 0;
+  hub._recentLogHashes.clear();
+  // Most tests here are about queueing mechanics rather than redaction, so the
+  // shared default is the verbose end; the tests that care set their own.
+  hub.config = { logLevel: "FINE", consoleEnabled: false };
+  // Auto-flush on batch size is real behaviour, exercised in its own test
+  // below; left on here it would drain the queue the other assertions read.
+  hub.maxBatchSize = Infinity;
+});
+
+describe("one threshold governs both destinations", () => {
+  it("emits nothing below the threshold, to either destination", () => {
+    const captured = [];
+    const realLog = console.log;
+    console.log = (...args) => captured.push(args);
+    try {
+      hub.config = { logLevel: "INFO", consoleEnabled: true };
+      hub.debug("fine-detail", "test.category");
+    } finally {
+      console.log = realLog;
+    }
+
+    assert.equal(hub.logs.length, 0, "a FINE line is not queued at INFO");
+    assert.equal(captured.length, 0, "and it is not printed either");
+  });
+
+  it("keeps WARNING and SEVERE visible at the INFO default", () => {
+    // Severity is a floor, not a filter: the labels exist so a query can
+    // isolate failures, never to hide them from the default configuration.
+    hub.config = { logLevel: "INFO", consoleEnabled: false };
+    hub.error("boom", "test.category");
+    hub.warn("careful", "test.category");
+    hub.info("normal", "test.category");
+    hub.debug("verbose", "test.category");
+
+    assert.deepEqual(
+      hub.logs.map((l) => l.logLine),
+      ["boom", "careful", "normal"],
+    );
+  });
+
+  it("queues FINE once the threshold is FINE", () => {
+    hub.config = { logLevel: "FINE", consoleEnabled: false };
+    hub.debug("fine-detail", "test.category");
+    assert.deepEqual(
+      hub.logs.map((l) => l.logLine),
+      ["fine-detail"],
+    );
+  });
+
+  it("stamps the platform's level spelling, not the old one", () => {
+    // The log viewer filters severity on `fine|config|info|warning|severe`.
+    // Emitting ERROR/WARN/DEBUG made extension sessions unfilterable next to
+    // the InApp SDK's.
+    hub.config = { logLevel: "FINE", consoleEnabled: false };
+    hub.error("a", "t");
+    hub.warn("b", "t");
+    hub.info("c", "t");
+    hub.debug("d", "t");
+
+    assert.deepEqual(
+      hub.logs.map((l) => l.logLevel),
+      ["SEVERE", "WARNING", "INFO", "FINE"],
+    );
+  });
+
+  it("accepts the pre-rename spellings from a persisted config", () => {
+    // A consumer who called setLogConfig({ logLevel: "DEBUG" }) before the
+    // rename still has that value in chrome.storage.local.
+    hub.config = { logLevel: "DEBUG", consoleEnabled: false };
+    hub.debug("still-verbose", "test.category");
+    assert.equal(hub.logs.length, 1, "DEBUG must still mean FINE");
+
+    hub.logs = [];
+    hub.config = { logLevel: "ERROR", consoleEnabled: false };
+    hub.info("dropped", "test.category");
+    hub.error("kept", "test.category");
+    assert.deepEqual(
+      hub.logs.map((l) => l.logLine),
+      ["kept"],
+    );
+  });
+});
+
+describe("redaction follows the level, not the destination", () => {
+  const TEMPLATE = {
+    sessionId: "sess-1",
+    signature: "0xsignaturevalue",
+    parameters: { accountNumber: "1234567890" },
+  };
+
+  it("redacts at INFO on the way to the endpoint", () => {
+    hub.config = { logLevel: "INFO", consoleEnabled: false };
+    hub.info("Starting verification:", "background.verification", { payload: TEMPLATE });
+
+    const line = hub.logs[0].logLine;
+    assert.ok(!line.includes("0xsignaturevalue"), "signature must not reach the endpoint");
+    assert.ok(!line.includes("1234567890"), "user parameters must not reach the endpoint");
+    assert.ok(line.includes("accountNumber"), "field names stay: they are the diagnostic");
+    assert.ok(line.includes("sess-1"), "innocuous fields are untouched");
+  });
+
+  it("redacts the CONSOLE at INFO too", () => {
+    // The property the old destination-based split could not express. The
+    // console is the provider tab's console; at the default level it must not
+    // show the user their own extracted data either.
+    const captured = [];
+    const realLog = console.log;
+    console.log = (...args) => captured.push(args);
+    try {
+      hub.config = { logLevel: "INFO", consoleEnabled: true };
+      hub.info("Starting verification:", "background.verification", { payload: TEMPLATE });
+    } finally {
+      console.log = realLog;
+    }
+
+    assert.equal(captured.length, 1);
+    const shown = captured[0][1];
+    // Still an object, so devtools renders a tree — but a redacted copy, and
+    // emphatically not the caller's live object.
+    assert.notEqual(shown, TEMPLATE, "the console must not get the live object at INFO");
+    assert.ok(!JSON.stringify(shown).includes("0xsignaturevalue"));
+    assert.ok(!JSON.stringify(shown).includes("1234567890"));
+  });
+
+  it("gives both destinations the raw values at FINE", () => {
+    const captured = [];
+    const realLog = console.log;
+    console.log = (...args) => captured.push(args);
+    try {
+      hub.config = { logLevel: "FINE", consoleEnabled: true };
+      hub.info("Starting verification:", "background.verification", { payload: TEMPLATE });
+    } finally {
+      console.log = realLog;
+    }
+
+    // This is the point of FINE: a client's failing session is diagnosed from
+    // Loki, so the endpoint gets exactly what the console gets.
+    const line = hub.logs[0].logLine;
+    assert.ok(line.includes("0xsignaturevalue"), "FINE ships the real value remotely");
+    assert.ok(line.includes("1234567890"));
+    assert.equal(captured[0][1], TEMPLATE, "the console gets the live object at FINE");
+  });
+
+  it("caps the redacted line, and allows a much longer raw one", () => {
+    hub.config = { logLevel: "INFO", consoleEnabled: false };
+    hub.info("big:", "test.category", { payload: { blob: "z".repeat(40000) } });
+    assert.ok(hub.logs[0].logLine.length < 2100, "a redacted line stays at the normal cap");
+
+    hub.logs = [];
+    hub._recentLogHashes.clear();
+    hub.config = { logLevel: "FINE", consoleEnabled: false };
+    hub.info("big:", "test.category", { payload: { blob: "z".repeat(40000) } });
+    assert.ok(hub.logs[0].logLine.length > 20000, "a raw claim must not be cut in half");
+    assert.ok(hub.logs[0].logLine.length <= 100_100, "but the bound is still finite");
+  });
+});
+
+describe("no user data reaches the endpoint at the default level", () => {
+  // The regression this file exists for. Everything below was, at one point,
+  // POSTed to Loki by a stock install that had called nothing.
+  const CLAIM = {
+    name: "http",
+    params: {
+      url: "https://etherscan.io/myaccount",
+      paramValues: { etherscanaccount: "sajjad21990" },
+    },
+    secretParams: {
+      cookieStr: "ASP.NET_SessionId=deadbeef; etherscan_pwd=hunter2",
+      paramValues: { secretToken: "tok-abc123" },
+    },
+    ownerPrivateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    signature: "0xsignaturevalue",
+  };
+
+  // A formatted proof as sessionManager builds it. `claimData` is the
+  // attestor's claim: `parameters` and `context` arrive as JSON *strings*, and
+  // `context.extractedParameters` is the plaintext value being proven.
+  const PROOF = {
+    identifier: "0xe46c982a",
+    claimData: {
+      provider: "http",
+      parameters: JSON.stringify({ paramValues: { username: "sajjad21990" } }),
+      context: JSON.stringify({ extractedParameters: { username: "sajjad21990" } }),
+      owner: "0xowner",
+    },
+    signatures: ["0x0ed30f08"],
+    witnesses: [{ id: "0x24489757", url: "wss://attestor.reclaimprotocol.org/ws" }],
+    publicData: "scraped-display-name",
+    providerRequest: { url: "https://kaggle.com/api", method: "POST", urlType: "TEMPLATE" },
+  };
+
+  const SECRETS = [
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    "ASP.NET_SessionId=deadbeef",
+    "etherscan_pwd=hunter2",
+    "tok-abc123",
+    "sajjad21990",
+    "0xsignaturevalue",
+    "scraped-display-name",
+  ];
+
+  it("blanks the claim at the stock defaults", () => {
+    hub.config = { ...DEFAULT_LOG_CONFIG };
+    hub.info("[CLAIM-CREATOR] Claim object:", "claim.creation", { payload: CLAIM });
+
+    const line = hub.logs[0]?.logLine ?? "";
+    for (const secret of SECRETS) {
+      assert.ok(!line.includes(secret), `${secret} LEAKED at stock defaults`);
+    }
+    assert.ok(line.includes("<redacted"), "values are blanked, not the whole line dropped");
+    // Key names survive where they are diagnostic and the value is not the
+    // secret itself — `secretParams` is blanked whole, but the shape around it
+    // still says which parameters the claim carried.
+    assert.ok(line.includes("etherscanaccount"), "param NAMES survive; their values do not");
+    assert.ok(line.includes("https://etherscan.io/myaccount"), "the provider url is config");
+  });
+
+  it("blanks claimData wholesale in a submitted proof", () => {
+    // `claimData.context.extractedParameters` is the proven value itself. The
+    // InApp SDK blanks exactly this field in its own PROOF_GENERATED line, and
+    // walking into it key-by-key would expose every field the attestor adds
+    // later until someone remembered to list it.
+    hub.config = { ...DEFAULT_LOG_CONFIG };
+    hub.info("[BACKGROUND] Submitting proofs", "background.proof", { payload: [PROOF] });
+
+    const line = hub.logs[0].logLine;
+    assert.ok(!line.includes("sajjad21990"), "the proven value must not reach Loki");
+    assert.ok(!line.includes("extractedParameters"), "not even the key");
+    assert.ok(line.includes('"claimData":"[REDACTED]"'));
+    // What stays is what makes the line worth having.
+    assert.ok(line.includes("0xe46c982a"), "the identifier survives");
+    assert.ok(line.includes("0x24489757"), "so does the attestor that signed it");
+    assert.ok(line.includes("urlType"), "and the provider request");
+  });
+
+  it("blanks a provider script's return value, whatever keys it invents", () => {
+    // A customInjection can return anything; no substring rule can anticipate
+    // its key names, so the whole value is opaque at INFO.
+    hub.config = { ...DEFAULT_LOG_CONFIG };
+    hub.info("[BACKGROUND] RUN_CUSTOM_INJECTION result", "background.injection", {
+      payload: { injectionResult: { emailAddress: "user@example.com", tier: "gold" } },
+    });
+
+    const line = hub.logs[0].logLine;
+    assert.ok(!line.includes("user@example.com"));
+    assert.ok(!line.includes("emailAddress"));
+    assert.ok(line.includes('"injectionResult":"[REDACTED]"'));
+  });
+
+  it("keeps the message itself, so the timeline survives redaction", () => {
+    hub.config = { ...DEFAULT_LOG_CONFIG };
+    hub.info("[CLAIM-CREATOR] Claim object:", "claim.creation", { payload: CLAIM });
+    assert.ok(
+      hub.logs[0].logLine.startsWith("[CLAIM-CREATOR] Claim object:"),
+      "the marker that the flow got this far must not be lost",
+    );
+  });
+
+  it("ships all of it at FINE, including across the relay", () => {
+    // offscreen.js logs the final claimData through RemoteLogger, so the level
+    // has to survive the chrome-messaging hop into handleRemoteLog.
+    hub.config = { logLevel: "FINE", consoleEnabled: false };
+    hub.handleRemoteLog(
+      "[OFFSCREEN] Final claimData for attestor",
+      "offscreen.proof",
+      "FINE",
+      "offscreen",
+      { payload: CLAIM },
+    );
+
+    const entry = hub.logs[0];
+    assert.equal(entry.context, "offscreen");
+    assert.ok(entry.logLine.includes("ASP.NET_SessionId=deadbeef"));
+    assert.ok(
+      entry.logLine.includes("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"),
+    );
+  });
+
+  it("reports a successful extraction without publishing what was extracted", () => {
+    // The success half of the extraction chain is logged at INFO on purpose: a
+    // selector that resolves to the wrong region is otherwise indistinguishable
+    // from one that was never evaluated until the attestor rejects the claim.
+    // What makes that safe is that the selector and the value LENGTH carry the
+    // diagnosis, while the value itself rides the payload under a key the
+    // redactor treats as opaque.
+    hub.config = { ...DEFAULT_LOG_CONFIG };
+    hub.info(
+      "[PARAM-EXTRACTOR] responseMatch #0 resolved via template: userName(len=11)",
+      "claim.params",
+      { payload: { extractedParameters: { userName: "sajjad21990" } } },
+    );
+
+    const line = hub.logs[0].logLine;
+    assert.ok(!line.includes("sajjad21990"), "the extracted value must not reach the endpoint");
+    assert.ok(line.includes("len=11"), "its length is the substitute, and is the diagnostic");
+    assert.ok(line.includes('"extractedParameters":"[REDACTED]"'));
+
+    hub.logs = [];
+    hub._recentLogHashes.clear();
+    hub.config = { logLevel: "FINE", consoleEnabled: false };
+    hub.info(
+      "[PARAM-EXTRACTOR] responseMatch #0 resolved via template: userName(len=11)",
+      "claim.params",
+      { payload: { extractedParameters: { userName: "sajjad21990" } } },
+    );
+    assert.ok(
+      hub.logs[0].logLine.includes("sajjad21990"),
+      "FINE is what a remote client debug session turns on",
+    );
+  });
+});
+
+describe("eventType", () => {
+  it("stamps the cross-SDK lifecycle name on the entry", () => {
+    hub.info("Fetched providers", "background.provider", {
+      eventType: "FETCHED_PROVIDERS",
+    });
+    assert.equal(hub.logs[0].eventType, "FETCHED_PROVIDERS");
+    // The dotted category is a separate axis and survives alongside it.
+    assert.equal(hub.logs[0].type, "background.provider");
+  });
+
+  it("defaults to UNKNOWN rather than omitting the field", () => {
+    // Always present, so it can be a Loki label without holes.
+    hub.info("no event name", "test.category");
+    assert.equal(hub.logs[0].eventType, "UNKNOWN");
+  });
+
+  it("carries through a relayed log", () => {
+    hub.handleRemoteLog(
+      "Intercepted GET https://x/y",
+      "interceptor.network",
+      "INFO",
+      "interceptor",
+      {
+        eventType: "REQUEST_INTERCEPTED",
+      },
+    );
+    assert.equal(hub.logs[0].eventType, "REQUEST_INTERCEPTED");
+    assert.equal(hub.logs[0].context, "interceptor");
+  });
+
+  it("does not collapse the same wording at two different lifecycle points", () => {
+    // The dedupe key includes eventType: identical text meaning two different
+    // things is two events, and losing one loses the transition.
+    hub.info("same words", "test.category", { eventType: "PREPARING_CLAIM" });
+    hub.info("same words", "test.category", { eventType: "CLAIM_CREATION_STARTED" });
+    assert.equal(hub.logs.length, 2);
+  });
+
+  it("uses names that exist in the InApp SDK where one exists", () => {
+    // Guards the renames: these spellings are the InApp ones, and drifting back
+    // to the old extension-local names silently breaks cross-SDK queries.
+    const names = new Set(Object.keys(EVENT_TYPES));
+    for (const inApp of [
+      "NO_RESPONSE_MATCH_WARNING",
+      "PROOF_GENERATED",
+      "PROOF_GENERATION_FAILED_EXCEPTION",
+      "CLAIM_CREATION_CANCELLED_EXCEPTION",
+      "RECLAIM_EXCEPTION",
+      "FETCHED_PROVIDERS",
+      "REQUEST_INTERCEPTED",
+      "PROVIDER_SCRIPT_REQUESTED_CLAIM",
+      "CLAIM_CREATION_TIMED_OUT_EXCEPTION",
+    ]) {
+      assert.ok(names.has(inApp), `missing InApp name ${inApp}`);
+    }
+    for (const retired of [
+      "RESPONSE_MATCH_FAILED",
+      "CLAIM_CREATION_SUCCESS",
+      "CLAIM_CREATION_FAILED",
+      "PROOF_GENERATION_ABORTED",
+      "VERIFICATION_FLOW_FAILED",
+      "FILTERED_REQUEST_FOUND",
+      "SUBMITTING_PROOF_TO_CALLBACK_URL",
+    ]) {
+      assert.ok(!names.has(retired), `${retired} was renamed away; do not reintroduce it`);
+    }
+    // Every value must equal its key, or a call site's constant and the stored
+    // string diverge.
+    for (const [key, value] of Object.entries(EVENT_TYPES)) {
+      assert.equal(key, value, `EVENT_TYPES.${key} !== "${value}"`);
+    }
+  });
+});
+
+describe("entry shape", () => {
+  it("stamps SDK identity, context and session identifiers on every entry", () => {
+    hub.sessionContext = { sessionId: "sess-1", providerId: "prov-1", appId: "app-1" };
+    hub.info("hello", "test.category");
+
+    const entry = hub.logs[0];
+    assert.equal(entry.sessionId, "sess-1");
+    assert.equal(entry.providerId, "prov-1");
+    assert.equal(entry.appId, "app-1");
+    assert.equal(entry.logLevel, "INFO");
+    assert.equal(entry.type, "test.category");
+    assert.equal(entry.context, "background");
+    assert.ok(entry.source.includes("browser-extension-sdk"), "entry must name the SDK");
+    assert.ok(/^\d+$/.test(entry.ts), "ts is Loki nanoseconds");
+  });
+
+  it("labels a relayed log with its originating context, not background", () => {
+    // "WARN" is the pre-rename spelling: a page-world script built before the
+    // rename can still be the one relaying, so it must normalize on arrival
+    // rather than reaching Loki under a name the viewer cannot filter.
+    hub.handleRemoteLog("from the page", "interceptor.network", "WARN", "interceptor");
+    assert.equal(hub.logs[0].context, "interceptor");
+    assert.equal(hub.logs[0].logLevel, "WARNING");
+  });
+
+  it("falls back to 'unknown' rather than dropping a log with no session", () => {
+    hub.sessionContext = { sessionId: null, providerId: null, appId: null };
+    hub.info("before any session", "test.category");
+    assert.equal(hub.logs.length, 1);
+    assert.equal(hub.logs[0].sessionId, "unknown");
+  });
+});
+
+describe("deduplication", () => {
+  it("counts a repeat instead of silently discarding it", () => {
+    hub.info("same line", "test.category");
+    hub.info("same line", "test.category");
+    hub.info("same line", "test.category");
+
+    assert.equal(hub.logs.length, 1, "repeats collapse into one entry");
+    assert.equal(hub.logs[0].repeated, 3, "but the count survives");
+  });
+
+  it("does not collapse the same wording from two different contexts", () => {
+    hub.handleRemoteLog("identical", "test.category", "INFO", "content");
+    hub.handleRemoteLog("identical", "test.category", "INFO", "offscreen");
+    assert.equal(hub.logs.length, 2);
+  });
+
+  it("does not collapse the same wording at two different levels", () => {
+    hub.info("identical", "test.category");
+    hub.error("identical", "test.category");
+    assert.equal(hub.logs.length, 2);
+  });
+});
+
+describe("truncateLine", () => {
+  it("leaves normal lines untouched", () => {
+    assert.equal(truncateLine("short"), "short");
+  });
+
+  it("caps a huge line and keeps both ends", () => {
+    const huge = "HEAD" + "x".repeat(50000) + "TAIL";
+    const out = truncateLine(huge);
+    assert.ok(out.length < 2100, `expected a capped line, got ${out.length}`);
+    assert.ok(out.startsWith("HEAD"), "the start says what happened");
+    assert.ok(out.endsWith("TAIL"), "the end usually holds the error");
+    assert.ok(out.includes("chars truncated"));
+  });
+
+  it("is applied to queued entries", () => {
+    hub.info("y".repeat(40000), "test.category");
+    assert.ok(hub.logs[0].logLine.length < 2100);
+  });
+
+  it("stringifies non-string input rather than throwing", () => {
+    assert.equal(truncateLine(undefined), "");
+    assert.equal(truncateLine(42), "42");
+  });
+});
+
+describe("flush", () => {
+  it("sends the batch with the SDK identity as the envelope source", async () => {
+    hub.info("one", "test.category");
+    hub.info("two", "test.category");
+    await hub.flush();
+
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].logs.length, 2);
+    assert.ok(sent[0].source.includes("browser-extension-sdk"));
+    assert.ok(sent[0].deviceId);
+  });
+
+  it("re-queues the batch when the endpoint rejects it", async () => {
+    const ok = globalThis.fetch;
+    globalThis.fetch = async () => ({ ok: false, status: 503 });
+    try {
+      hub.info("must not be lost", "test.category");
+      await hub.flush();
+      assert.equal(hub.logs.length, 1, "a failed POST must not consume the logs");
+      assert.equal(hub.logs[0].logLine, "must not be lost");
+    } finally {
+      globalThis.fetch = ok;
+    }
+  });
+
+  it("re-queues when the request throws outright", async () => {
+    const ok = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new Error("offline");
+    };
+    try {
+      hub.info("offline log", "test.category");
+      await hub.flush();
+      assert.equal(hub.logs.length, 1);
+    } finally {
+      globalThis.fetch = ok;
+    }
+  });
+
+  it("is a no-op with an empty queue", async () => {
+    await hub.flush();
+    assert.equal(sent.length, 0);
+  });
+
+  it("never skips a batch because another flush is in flight", async () => {
+    // Regression guard, from a real loss: a session's last 14 seconds — the
+    // proof failure and the failSession path, i.e. the only logs that explained
+    // the failure — never reached the endpoint, while everything before them
+    // did. flush() used to return early whenever `isFlushing` was set and
+    // forceFlush() polled for just one second before calling it anyway, so a
+    // terminal flush that overlapped a slow periodic POST silently sent nothing.
+    const ok = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async (url, init) => {
+      calls++;
+      // The first POST stays open longer than the old one-second poll, which is
+      // what made that poll useless — 1.2s is an ordinary slow mobile request.
+      if (calls === 1) await new Promise((resolve) => setTimeout(resolve, 1200));
+      sent.push(JSON.parse(init.body));
+      return { ok: true, status: 201 };
+    };
+    try {
+      hub.info("first batch", "test.category");
+      const slow = hub.flush();
+
+      // Terminal logs arrive while the first POST is still open.
+      hub.info("the failure everyone needs", "test.category");
+      const terminal = hub.forceFlush();
+
+      await Promise.all([slow, terminal]);
+
+      const lines = sent.flatMap((b) => b.logs.map((l) => l.logLine));
+      assert.ok(
+        lines.includes("the failure everyone needs"),
+        `terminal batch was dropped; endpoint only got ${JSON.stringify(lines)}`,
+      );
+      assert.equal(hub.logs.length, 0, "nothing may be left queued after both flushes");
+    } finally {
+      globalThis.fetch = ok;
+    }
+  });
+});
+
+describe("session context", () => {
+  it("keeps the identifiers on logs emitted after a terminal path", async () => {
+    // failSession() calls clearSessionContext() and the flow then keeps going:
+    // it notifies tabs, broadcasts to the popup and answers further messages.
+    // Nulling the ids there stamped all of that "unknown", which does not just
+    // lose attribution — it makes those lines unreachable from a sessionId
+    // query, i.e. invisible in the one view used to debug the failure.
+    hub.setSessionContext({ sessionId: "abc123", providerId: "prov", appId: "app" });
+    await hub.clearSessionContext();
+
+    hub.info("emitted after failSession", "test.category");
+
+    assert.equal(hub.logs.at(-1).sessionId, "abc123");
+    assert.equal(hub.logs.at(-1).providerId, "prov");
+  });
+
+  it("does not let a restored context clobber one just set", async () => {
+    storage.session.set("reclaim_log_session_context", {
+      sessionId: "stale",
+      providerId: "old",
+      appId: "old",
+    });
+    hub.setSessionContext({ sessionId: "current", providerId: "p", appId: "a" });
+
+    await hub._restoreSessionContext();
+
+    assert.equal(hub.sessionContext.sessionId, "current");
+  });
+});
+
+describe("service-worker restart", () => {
+  it("mirrors the pending queue into session storage", () => {
+    hub.info("survives teardown", "test.category");
+    const persisted = storage.session.get("reclaim_extension_sdk_log_queue");
+    assert.ok(Array.isArray(persisted), "queue must be mirrored, not memory-only");
+    assert.equal(persisted.at(-1).logLine, "survives teardown");
+  });
+
+  it("clears the mirror once the batch is sent", async () => {
+    hub.info("transient", "test.category");
+    await hub.flush();
+    assert.equal(storage.session.get("reclaim_extension_sdk_log_queue"), undefined);
+  });
+
+  it("recovers logs left behind by a previous worker lifetime", async () => {
+    const orphan = { logLine: "from the previous life", ts: "1", logLevel: "INFO" };
+    storage.session.set("reclaim_extension_sdk_log_queue", [orphan]);
+
+    await hub._drainPersisted();
+
+    assert.equal(hub.logs[0].logLine, "from the previous life");
+    assert.equal(
+      storage.session.get("reclaim_extension_sdk_log_queue"),
+      undefined,
+      "recovered logs must not be replayed a second time",
+    );
+  });
+});
+
+describe("batching", () => {
+  it("flushes as soon as the batch size is reached", async () => {
+    hub.maxBatchSize = 3;
+    hub.info("a", "test.category");
+    hub.info("b", "test.category");
+    hub.info("c", "test.category");
+    // The flush is kicked off synchronously inside the third _addLog; let the
+    // POST settle.
+    await hub.ready;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].logs.length, 3);
+  });
+});
+
+describe("queue cap", () => {
+  it("drops the oldest logs rather than growing without bound", () => {
+    for (let i = 0; i < hub.maxQueueSize + 25; i++) {
+      // Distinct messages so dedupe does not interfere.
+      hub._addLog(`log ${i}`, "test.category", "INFO");
+    }
+    assert.equal(hub.logs.length, hub.maxQueueSize);
+    assert.ok(hub.stats.totalLogsDropped >= 25);
+    // The survivors are the newest.
+    assert.equal(hub.logs.at(-1).logLine, `log ${hub.maxQueueSize + 24}`);
+  });
+});

--- a/src/utils/logger/redact.js
+++ b/src/utils/logger/redact.js
@@ -1,0 +1,163 @@
+/**
+ * Redaction for objects that get stringified into log lines.
+ *
+ * Diagnostic logs leave the device: they are POSTed to the logging endpoint and
+ * land in Loki, where they are readable by anyone with dashboard access. Two
+ * kinds of value must never make that trip:
+ *
+ *  - credentials — `signature` authenticates the session-init request
+ *  - user data — `parameters` holds whatever the provider script needs, which
+ *    for a real provider is exactly the sensitive value being proven (account
+ *    number, email, balance)
+ *
+ * Keys are matched case-insensitively on substrings, so `appSecret`,
+ * `secretKey` and `SECRET` are all caught by one entry. The shape is preserved
+ * — a redacted log still shows which fields were present, which is usually the
+ * diagnostic question — and the value is replaced with a marker that records
+ * enough to correlate without disclosing.
+ */
+
+const SENSITIVE_KEY_PATTERNS = [
+  "signature",
+  "secret",
+  "password",
+  "token",
+  "cookie",
+  "authorization",
+  "privatekey",
+  "apikey",
+];
+
+/**
+ * Keys whose values are user data: keep the key names, drop the values.
+ *
+ * These are matched whatever the value's TYPE is. That matters because the
+ * attestor hands several of them back as JSON *strings* rather than objects —
+ * `claim.parameters` is a serialised blob holding `paramValues`, and a
+ * string-only-if-object check let the whole thing through untouched.
+ */
+const USER_DATA_KEYS = ["parameters", "paramvalues", "publicdata", "witnessparameters"];
+
+/**
+ * Keys replaced wholesale, without descending into them.
+ *
+ * `claimData` is the attestor's claim: `parameters` (the substituted request,
+ * including `paramValues`) and `context` (which carries `extractedParameters` —
+ * the plaintext value the user is proving). There is nothing inside it worth
+ * keeping at INFO, and walking it key-by-key means every future field the
+ * attestor adds is exposed until someone remembers to list it here. The InApp
+ * SDK blanks exactly this field in its own PROOF_GENERATED line.
+ *
+ * `rdObject` is the request descriptor a provider script hands to
+ * `window.Reclaim.requestClaim()`. Like `injectionResult` it is provider-shaped
+ * — it routinely carries the response the claim is being built from — so no
+ * substring rule can anticipate its key names either.
+ */
+const OPAQUE_KEYS = ["claimdata", "context", "extractedparameters", "injectionresult", "rdobject"];
+
+/**
+ * Keys carrying raw response or page content as a STRING.
+ *
+ * `USER_DATA_KEYS` only covers object values, so a plain string of the user's
+ * authenticated page would otherwise travel verbatim. The length is kept
+ * because it is the actual diagnostic: it separates "the selector matched
+ * nothing" from "it matched the wrong region". Deliberately narrow — bare
+ * `body` is NOT here, because a claim's `params.body` is a provider-authored
+ * request template, which is config worth reading, not user data.
+ */
+const RESPONSE_CONTENT_KEYS = ["element", "responsebody", "responsetext"];
+
+function isSensitive(key) {
+  const lower = String(key).toLowerCase();
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+function isUserData(key) {
+  return USER_DATA_KEYS.includes(String(key).toLowerCase());
+}
+
+function isOpaque(key) {
+  return OPAQUE_KEYS.includes(String(key).toLowerCase());
+}
+
+function isResponseContent(key) {
+  return RESPONSE_CONTENT_KEYS.includes(String(key).toLowerCase());
+}
+
+/**
+ * Deep-copy `value` with sensitive fields replaced.
+ *
+ * @param {*} value
+ * @param {number} [depth] - recursion guard for cyclic or pathological objects
+ * @returns {*}
+ */
+export function redact(value, depth = 0) {
+  if (depth > 8) return "<max-depth>";
+  if (value === null || typeof value !== "object") return value;
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redact(item, depth + 1));
+  }
+
+  const out = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (isSensitive(key)) {
+      out[key] = typeof val === "string" ? `<redacted:${val.length} chars>` : "<redacted>";
+    } else if (isOpaque(key)) {
+      out[key] = "[REDACTED]";
+    } else if (isUserData(key)) {
+      // Field names are safe and useful; the values are the user's data. An
+      // object keeps its key names; a string (the attestor serialises several of
+      // these) keeps only its length.
+      out[key] =
+        val && typeof val === "object"
+          ? `<redacted keys: ${Object.keys(val).join(", ") || "none"}>`
+          : typeof val === "string"
+            ? `<redacted:${val.length} chars>`
+            : "<redacted>";
+    } else if (isResponseContent(key) && typeof val === "string") {
+      out[key] = `<redacted:${val.length} chars>`;
+    } else {
+      out[key] = redact(val, depth + 1);
+    }
+  }
+  return out;
+}
+
+/**
+ * Redact then stringify, for direct interpolation into a log line.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+export function redactedJson(value) {
+  try {
+    return JSON.stringify(redact(value));
+  } catch {
+    return "<unserializable>";
+  }
+}
+
+/**
+ * Stringify WITHOUT redacting, for the FINE log path.
+ *
+ * Everything in the module header applies in reverse here: a value serialised by
+ * this function reaches Loki verbatim, credentials included. That is the point
+ * of FINE — a claim that fails at the attestor is only diagnosable from the
+ * exact bytes that were sent, and a client's failing session has to be readable
+ * remotely, with their permission.
+ *
+ * One guard, and it must stay: `LoggingHub._addLog` reaches this function only
+ * while `logLevel` is FINE, which is never the default. At INFO every payload
+ * goes through `redact()` instead, for the console as well as the endpoint.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+export function unredactedJson(value) {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "<unserializable>";
+  }
+}

--- a/src/utils/logger/redact.test.js
+++ b/src/utils/logger/redact.test.js
@@ -1,0 +1,144 @@
+/**
+ * These logs leave the device. The router used to stringify the whole
+ * templateData into a log line, which put the session `signature` and the
+ * provider `parameters` — the user's actual private data — into Loki. These
+ * tests exist to keep that from coming back.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import { redact, redactedJson } from "./redact.js";
+
+describe("redact", () => {
+  it("removes the session signature but records that it was present", () => {
+    const out = redact({ sessionId: "s1", signature: "0xdeadbeef" });
+    assert.equal(out.sessionId, "s1");
+    assert.ok(!JSON.stringify(out).includes("0xdeadbeef"));
+    assert.equal(out.signature, "<redacted:10 chars>");
+  });
+
+  it("keeps parameter names but drops parameter values", () => {
+    const out = redact({ parameters: { accountNumber: "1234567890", email: "a@b.com" } });
+    const json = JSON.stringify(out);
+    assert.ok(!json.includes("1234567890"));
+    assert.ok(!json.includes("a@b.com"));
+    // Names are the diagnostic question ("did the script get the param?"),
+    // values are the user's data.
+    assert.ok(json.includes("accountNumber"));
+    assert.ok(json.includes("email"));
+  });
+
+  it("matches sensitive keys case-insensitively and as substrings", () => {
+    const out = redact({
+      appSecret: "s",
+      AUTHORIZATION: "Bearer x",
+      apiKey: "k",
+      cookieHeader: "a=b",
+      nested: { privateKey: "p" },
+    });
+    const json = JSON.stringify(out);
+    for (const leaked of ["Bearer x", "a=b"]) {
+      assert.ok(!json.includes(leaked), `${leaked} leaked`);
+    }
+    assert.equal(out.nested.privateKey, "<redacted:1 chars>");
+  });
+
+  it("recurses into arrays and leaves innocuous data intact", () => {
+    const out = redact({
+      requestData: [
+        { url: "https://x/y", method: "GET", signature: "sig" },
+        { url: "https://x/z", method: "POST" },
+      ],
+    });
+    assert.equal(out.requestData[0].url, "https://x/y");
+    assert.equal(out.requestData[0].signature, "<redacted:3 chars>");
+    assert.equal(out.requestData[1].method, "POST");
+  });
+
+  it("terminates on cyclic objects instead of blowing the stack", () => {
+    const cyclic = { name: "a" };
+    cyclic.self = cyclic;
+    assert.doesNotThrow(() => redact(cyclic));
+    assert.ok(JSON.stringify(redact(cyclic)).includes("max-depth"));
+  });
+
+  it("passes primitives through untouched", () => {
+    assert.equal(redact("plain"), "plain");
+    assert.equal(redact(7), 7);
+    assert.equal(redact(null), null);
+  });
+});
+
+describe("redactedJson", () => {
+  it("produces a string safe to interpolate into a log line", () => {
+    const json = redactedJson({ sessionId: "s", signature: "secret-sig" });
+    assert.ok(!json.includes("secret-sig"));
+    assert.ok(json.includes('"sessionId":"s"'));
+  });
+
+  it("never throws on unserializable input", () => {
+    const bad = {
+      get boom() {
+        throw new Error("no");
+      },
+    };
+    assert.equal(redactedJson(bad), "<unserializable>");
+  });
+});
+
+describe("response content", () => {
+  it("drops raw page content but keeps its length", () => {
+    // RedactionResolveError.element carries the region a failed selector was
+    // looking at — the user's authenticated page. The console needs it, the
+    // endpoint must not have it, and the length is what makes the log useful.
+    const out = redact({ element: "<strong>private-account-name</strong>" });
+    assert.equal(out.element, "<redacted:37 chars>");
+  });
+
+  it("leaves a provider-authored request body alone", () => {
+    // params.body is provider config, not user data. Redacting it would remove
+    // a genuinely useful diagnostic.
+    const out = redact({ body: '{"query":"{{param}}"}' });
+    assert.equal(out.body, '{"query":"{{param}}"}');
+  });
+});
+
+describe("attestor-shaped values", () => {
+  it("blanks claimData wholesale rather than walking into it", () => {
+    // claimData.context holds extractedParameters — the plaintext value being
+    // proven. Descending key-by-key would expose every field the attestor adds
+    // later until someone remembered to list it, so the whole thing is opaque.
+    const out = redact({
+      identifier: "0xabc",
+      claimData: {
+        parameters: JSON.stringify({ paramValues: { username: "sajjad21990" } }),
+        context: JSON.stringify({ extractedParameters: { username: "sajjad21990" } }),
+      },
+    });
+    assert.equal(out.claimData, "[REDACTED]");
+    assert.equal(out.identifier, "0xabc", "the identifier is not user data");
+  });
+
+  it("redacts user-data keys whose value is a STRING, not just an object", () => {
+    // The attestor serialises these. A `typeof val === "object"` guard let the
+    // whole blob through: this is the bug that published extractedParameters.
+    const out = redact({
+      parameters: JSON.stringify({ paramValues: { username: "sajjad21990" } }),
+      publicData: "scraped-display-name",
+      paramValues: { username: "sajjad21990" },
+    });
+    assert.ok(!JSON.stringify(out).includes("sajjad21990"));
+    assert.ok(!JSON.stringify(out).includes("scraped-display-name"));
+    assert.match(out.parameters, /^<redacted:\d+ chars>$/);
+    assert.match(out.publicData, /^<redacted:\d+ chars>$/);
+    assert.equal(out.paramValues, "<redacted keys: username>", "object form keeps its key names");
+  });
+
+  it("blanks a provider script's return value whatever it contains", () => {
+    // A customInjection can return anything; no substring rule can anticipate
+    // its keys, so the call site nests it under an opaque key.
+    const out = redact({ injectionResult: { emailAddress: "user@example.com" } });
+    assert.equal(out.injectionResult, "[REDACTED]");
+  });
+});

--- a/src/utils/mocks/jsdom-mock.js
+++ b/src/utils/mocks/jsdom-mock.js
@@ -53,7 +53,6 @@ module.exports = {
       return "<!DOCTYPE html><html><head></head><body></body></html>";
     }
 
-    // Static method for creating virtual console
     static createVirtualConsole() {
       return {
         on: () => {},

--- a/src/utils/mocks/koffi-mock.js
+++ b/src/utils/mocks/koffi-mock.js
@@ -3,7 +3,6 @@
  * This provides stub implementations of the methods used by the attestor-core package
  */
 
-// Create a stub library object
 const createLibraryStub = () => {
   return {
     func: () => () => {
@@ -13,9 +12,7 @@ const createLibraryStub = () => {
   };
 };
 
-// Main exports of the koffi module
 module.exports = {
-  // Main function to load a library
   load: function () {
     console.warn("Koffi.load called in browser environment - returning stub implementation");
     return createLibraryStub();

--- a/src/utils/polyfill-test.js
+++ b/src/utils/polyfill-test.js
@@ -5,10 +5,8 @@ import { createClaimOnAttestor } from "@reclaimprotocol/attestor-core";
 export const testPolyfills = () => {
   console.log("[POLYFILLS] Testing polyfills for @reclaimprotocol/attestor-core");
 
-  // Verify Buffer is available
   console.log("[POLYFILLS] Buffer available:", typeof Buffer !== "undefined");
 
-  // Verify process is available
   console.log("[POLYFILLS] process available:", typeof process !== "undefined");
 
   // Verify createClaimOnAttestor is a function

--- a/src/utils/polyfills.js
+++ b/src/utils/polyfills.js
@@ -13,12 +13,10 @@ const getGlobalObject = () => {
   return Function("return this")();
 };
 
-// Get the global object
 const global = getGlobalObject();
 
 // Check if we're in a service worker or browser environment
 const isServiceWorker = typeof window === "undefined";
-// Determine if we're in content script context
 const isContentScript = typeof document !== "undefined" && document.contentType !== undefined;
 
 // Make Buffer and process available globally
@@ -31,15 +29,8 @@ if (typeof global.WebSocket === "undefined" && !isContentScript) {
   try {
     const { WebSocket } = require("./websocket-polyfill");
     global.WebSocket = WebSocket;
-    console.log("[POLYFILLS] WebSocket polyfill added to global");
   } catch (e) {
     console.warn("[POLYFILLS] Failed to load WebSocket polyfill:", e);
-  }
-} else {
-  if (!isContentScript) {
-    console.log("[POLYFILLS] Using native WebSocket implementation");
-  } else {
-    console.log("[POLYFILLS] Skipping WebSocket in content script context");
   }
 }
 
@@ -56,7 +47,6 @@ if (typeof global.require !== "function") {
       case "ws":
         // Don't return WebSocket in content script context
         if (isContentScript) {
-          console.log("[POLYFILLS] Blocking ws module in content script");
           return {}; // Empty implementation for content script
         }
         try {
@@ -91,7 +81,6 @@ if (typeof global.require !== "function") {
     if (moduleName === "ws") {
       // Don't return WebSocket in content script context
       if (isContentScript) {
-        console.log("[POLYFILLS] Blocking ws module in content script");
         return {}; // Empty implementation for content script
       }
       try {
@@ -132,7 +121,6 @@ if (typeof global.global === "undefined") {
   global.global = global;
 }
 
-// Handle crypto.getRandomValues polyfill if needed
 if (typeof global.crypto === "undefined") {
   global.crypto = {};
 }
@@ -150,7 +138,6 @@ if (typeof global.crypto.getRandomValues === "undefined") {
 // Handle other potential missing WebCrypto APIs
 if (typeof global.crypto.subtle === "undefined") {
   console.warn("[POLYFILLS] WebCrypto subtle API not available. Some functionality may not work.");
-  // Create a minimal fallback for subtle crypto
   global.crypto.subtle = {
     digest: async (algorithm, data) => {
       console.warn(`[POLYFILLS] Crypto subtle digest (${algorithm}) called with browser fallback`);
@@ -160,7 +147,6 @@ if (typeof global.crypto.subtle === "undefined") {
         0,
       );
 
-      // Convert to a byte array of appropriate length
       const result = new Uint8Array(32); // SHA-256 length
       for (let i = 0; i < 32; i++) {
         result[i] = (hashInt >> (i * 8)) & 0xff;
@@ -189,7 +175,6 @@ if (!isServiceWorker) {
   // Override URL constructor to handle node:url protocol
   const OriginalURL = global.URL;
   function CustomURL(url, base) {
-    // Handle node:url protocol
     if (typeof url === "string" && url.startsWith("node:")) {
       url = url.replace(/^node:/, "");
     }

--- a/src/utils/proof-generator/proof-generator.js
+++ b/src/utils/proof-generator/proof-generator.js
@@ -1,11 +1,25 @@
-// Import polyfills
 import "../polyfills";
 
 import { MESSAGE_ACTIONS, MESSAGE_SOURCES } from "../constants/index";
 import { ensureOffscreenDocument } from "../offscreen-manager";
 import { PROOF_RESPONSE_TIMEOUT_MS } from "../constants/config";
+import { EVENT_TYPES } from "../logger/constants";
 
-// Main function to generate proof using offscreen document
+/**
+ * Reject with a real Error that still carries the `{success, error}` shape.
+ *
+ * These paths used to reject a plain object literal, so `error.message` in
+ * proofQueue's catch was `undefined` — the session's one explanation of a proof
+ * timeout read "Proof generation failed: undefined", and that string is also
+ * what reaches the consumer's Promise.
+ */
+const rejection = (message) => {
+  const error = new Error(message);
+  error.success = false;
+  error.error = message;
+  return error;
+};
+
 export const generateProof = async (claimData, loggingHub) => {
   try {
     if (!claimData) {
@@ -15,30 +29,31 @@ export const generateProof = async (claimData, loggingHub) => {
       );
       throw new Error("No claim data provided for proof generation");
     }
-    // Ensure the offscreen document exists and is ready
     await ensureOffscreenDocument(loggingHub);
 
     // Generate the proof using the offscreen document
     return new Promise((resolve, reject) => {
       const messageTimeout = setTimeout(() => {
-        loggingHub.error(
-          "[PROOF-GENERATOR] Timeout waiting for offscreen document to generate proof",
-          "proof.generation",
-        );
-        reject({
-          success: false,
-          error: "Timeout waiting for offscreen document to generate proof",
+        // Reaching this means the offscreen document never answered at all —
+        // its own PROOF_GENERATION_TIMEOUT_MS is shorter and would have replied
+        // with a more specific error first. Say so, rather than reporting it as
+        // a generic proof timeout.
+        const message =
+          "Offscreen document did not respond within " +
+          PROOF_RESPONSE_TIMEOUT_MS / 1000 +
+          "s (it should have reported its own timeout first — the document is likely gone)";
+        loggingHub.error("[PROOF-GENERATOR] " + message, "proof.generation", {
+          eventType: EVENT_TYPES.PROOF_GENERATION_FAILED_EXCEPTION,
         });
+        reject(rejection(message));
       }, PROOF_RESPONSE_TIMEOUT_MS);
 
-      // Create a message listener for the offscreen response
       const messageListener = (response) => {
         if (
           response.action === MESSAGE_ACTIONS.GENERATE_PROOF_RESPONSE &&
           response.source === MESSAGE_SOURCES.OFFSCREEN &&
           response.target === MESSAGE_SOURCES.BACKGROUND
         ) {
-          // Clear timeout and remove listener
           clearTimeout(messageTimeout);
           chrome.runtime.onMessage.removeListener(messageListener);
 
@@ -78,10 +93,8 @@ export const generateProof = async (claimData, loggingHub) => {
         }
       };
 
-      // Add listener for response
       chrome.runtime.onMessage.addListener(messageListener);
 
-      // Send message to offscreen document to generate proof
       chrome.runtime.sendMessage(
         {
           action: MESSAGE_ACTIONS.GENERATE_PROOF,
@@ -93,16 +106,14 @@ export const generateProof = async (claimData, loggingHub) => {
           if (chrome.runtime.lastError) {
             clearTimeout(messageTimeout);
             chrome.runtime.onMessage.removeListener(messageListener);
+            const message =
+              chrome.runtime.lastError.message || "Error communicating with offscreen document";
             loggingHub.error(
-              "[PROOF-GENERATOR] Error sending message to offscreen document: " +
-                chrome.runtime.lastError.message,
+              "[PROOF-GENERATOR] Error sending message to offscreen document: " + message,
               "proof.generation",
+              { eventType: EVENT_TYPES.PROOF_GENERATION_FAILED_EXCEPTION },
             );
-            reject({
-              success: false,
-              error:
-                chrome.runtime.lastError.message || "Error communicating with offscreen document",
-            });
+            reject(rejection(message));
           }
         },
       );

--- a/src/utils/provider-normalization.js
+++ b/src/utils/provider-normalization.js
@@ -1,0 +1,144 @@
+/**
+ * Normalizing provider config to what this SDK can actually honour.
+ *
+ * Provider documents are authored once and consumed by several very different
+ * runtimes (InApp/Flutter webview, the portal's headless browser, this
+ * extension). They therefore carry fields whose value space is wider than any
+ * one runtime supports. Silently passing an unsupported value through means a
+ * confusing runtime failure much later — a page with no interceptor, or a claim
+ * the attestor rejects — so normalize once, at the point the provider is
+ * fetched, and log when a value is coerced.
+ */
+
+/**
+ * Injection strategies the extension implements.
+ *
+ * The full upstream enum is MSWJS | XHOOK | HAWKEYE | NONE | CDP
+ * (reclaim-sdk-backend `InjectionType`; InApp adds UNKNOWN). This SDK has
+ * exactly two behaviours:
+ *
+ *   HAWKEYE → inject src/interceptor/network-interceptor.js into the MAIN world
+ *   NONE    → do not inject an interceptor at all
+ *
+ * There is no MSWJS/XHOOK/CDP code path here, so anything else falls back to
+ * HAWKEYE — which matches InApp, whose deserializer declares
+ * `defaultValue: InjectionType.HAWKEYE`. Falling back to NONE instead would
+ * silently disable interception and strand the session with no matched request
+ * until the session timer fires.
+ */
+export const INJECTION_TYPES = {
+  HAWKEYE: "HAWKEYE",
+  NONE: "NONE",
+};
+
+export const DEFAULT_INJECTION_TYPE = INJECTION_TYPES.HAWKEYE;
+
+/**
+ * The only OPRF mode this SDK supports.
+ *
+ * The attestor's schema allows `oprf | oprf-mpc | oprf-raw`
+ * (attestor-core `HttpProviderParameters.responseRedactions[].hash`). The
+ * extension only supports the raw variant, so any other truthy value is coerced
+ * rather than sent as-is: an unsupported mode would reach the attestor and fail
+ * proof generation after the user has already logged in.
+ *
+ * `hash` being absent/null is NOT hashing and must stay absent — coercing that
+ * would hash a value the provider intended to reveal.
+ */
+export const SUPPORTED_REDACTION_HASH = "oprf-raw";
+
+/**
+ * Coerce a provider's injectionType to one this SDK implements.
+ *
+ * @param {string} [injectionType] - raw value from provider data
+ * @param {Object} [logger] - optional logger, called only when coercing
+ * @returns {"HAWKEYE"|"NONE"}
+ */
+export function normalizeInjectionType(injectionType, logger) {
+  if (injectionType === INJECTION_TYPES.NONE) return INJECTION_TYPES.NONE;
+  if (injectionType === INJECTION_TYPES.HAWKEYE) return INJECTION_TYPES.HAWKEYE;
+
+  logger?.warn?.(
+    `[PROVIDER] Unsupported injectionType ${JSON.stringify(injectionType)}; ` +
+      `falling back to ${DEFAULT_INJECTION_TYPE}`,
+    "background.provider",
+  );
+  return DEFAULT_INJECTION_TYPE;
+}
+
+/**
+ * Coerce a responseRedaction `hash` to the one supported OPRF mode.
+ *
+ * @param {string|null} [hash] - raw value from provider data
+ * @param {Object} [logger] - optional logger, called only when coercing
+ * @returns {string|undefined} `"oprf-raw"`, or undefined when not hashing
+ */
+export function normalizeRedactionHash(hash, logger) {
+  // No hash means "reveal this normally" — leave it alone.
+  if (!hash) return undefined;
+  if (hash === SUPPORTED_REDACTION_HASH) return SUPPORTED_REDACTION_HASH;
+
+  logger?.warn?.(
+    `[PROVIDER] Unsupported redaction hash ${JSON.stringify(hash)}; ` +
+      `falling back to ${SUPPORTED_REDACTION_HASH}`,
+    "background.claim",
+  );
+  return SUPPORTED_REDACTION_HASH;
+}
+
+/**
+ * URL matching strategies, and how this SDK maps them.
+ *
+ * The upstream enum is `REGEX | CONSTANT | TEMPLATE` (InApp
+ * `UrlType` in lib/src/data/providers.dart). Note what is NOT in it: `EXACT`.
+ * That name is local to this SDK — it is what `matchesRequestCriteria` has always
+ * defaulted to and what the background writes on synthetic requests — so it is
+ * kept as an alias rather than removed.
+ *
+ *   CONSTANT | EXACT → compare the URL for equality
+ *   TEMPLATE | REGEX → build a regex from the template and test it
+ *
+ * `CONSTANT` is the canonical value for a plain URL AND upstream's default: InApp
+ * infers TEMPLATE when the url contains `{{` and CONSTANT otherwise. This SDK
+ * used to return `false` for it, so a provider authored with the normal default
+ * never matched any request at all — no claim, no proof, no diagnostic beyond
+ * "request intercepted", and the session died on the timer.
+ */
+export const URL_TYPES = {
+  CONSTANT: "CONSTANT",
+  TEMPLATE: "TEMPLATE",
+  REGEX: "REGEX",
+};
+
+/**
+ * Resolve a requestData `urlType` to one of CONSTANT / TEMPLATE / REGEX.
+ *
+ * An absent or unrecognised value is INFERRED from the url the same way InApp
+ * does, rather than being treated as unmatchable. That direction of failure is
+ * deliberate: guessing wrong costs one non-matching request, whereas refusing to
+ * match costs the whole verification.
+ *
+ * @param {string} [urlType]
+ * @param {string} [url] - used to infer when urlType is absent/unknown
+ * @param {{warn?: Function}} [logger]
+ * @returns {"CONSTANT"|"TEMPLATE"|"REGEX"}
+ */
+export function normalizeUrlType(urlType, url, logger) {
+  const raw = typeof urlType === "string" ? urlType.toUpperCase() : "";
+
+  if (raw === URL_TYPES.CONSTANT || raw === "EXACT") return URL_TYPES.CONSTANT;
+  if (raw === URL_TYPES.TEMPLATE) return URL_TYPES.TEMPLATE;
+  if (raw === URL_TYPES.REGEX) return URL_TYPES.REGEX;
+
+  const inferred =
+    typeof url === "string" && url.includes("{{") ? URL_TYPES.TEMPLATE : URL_TYPES.CONSTANT;
+
+  if (raw) {
+    logger?.warn?.(
+      `[PROVIDER] Unsupported urlType "${urlType}"; treating it as ${inferred}`,
+      "provider.normalization",
+    );
+  }
+
+  return inferred;
+}

--- a/src/utils/provider-normalization.test.js
+++ b/src/utils/provider-normalization.test.js
@@ -1,0 +1,102 @@
+/**
+ * Provider documents are authored for several runtimes at once, so their value
+ * space is wider than what this SDK implements. These tests pin the coercions,
+ * because getting either one wrong fails late and confusingly: an unsupported
+ * injectionType strands a session with no interceptor until the timer fires,
+ * and an unsupported OPRF mode fails at the attestor after the user has already
+ * logged in.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+import {
+  INJECTION_TYPES,
+  DEFAULT_INJECTION_TYPE,
+  SUPPORTED_REDACTION_HASH,
+  normalizeInjectionType,
+  normalizeRedactionHash,
+} from "./provider-normalization.js";
+
+/** Collects warn() calls so we can assert a coercion was reported, not silent. */
+function recorder() {
+  const warnings = [];
+  return { logger: { warn: (message) => warnings.push(message) }, warnings };
+}
+
+describe("normalizeInjectionType", () => {
+  it("passes through the two types the SDK implements", () => {
+    assert.equal(normalizeInjectionType("HAWKEYE"), "HAWKEYE");
+    assert.equal(normalizeInjectionType("NONE"), "NONE");
+  });
+
+  it("falls back to HAWKEYE for the upstream types with no code path here", () => {
+    // The full upstream enum is MSWJS | XHOOK | HAWKEYE | NONE | CDP.
+    for (const unsupported of ["MSWJS", "XHOOK", "CDP", "UNKNOWN"]) {
+      assert.equal(normalizeInjectionType(unsupported), "HAWKEYE", unsupported);
+    }
+  });
+
+  it("falls back for absent or malformed values", () => {
+    for (const bad of [undefined, null, "", "hawkeye", "None", 0, {}]) {
+      assert.equal(normalizeInjectionType(bad), DEFAULT_INJECTION_TYPE, JSON.stringify(bad));
+    }
+  });
+
+  it("never falls back to NONE — that would silently disable interception", () => {
+    // Defaulting to NONE looks conservative but means no interceptor is ever
+    // injected, so no request is ever matched and the session dies on the timer.
+    assert.notEqual(DEFAULT_INJECTION_TYPE, INJECTION_TYPES.NONE);
+    assert.equal(DEFAULT_INJECTION_TYPE, "HAWKEYE");
+  });
+
+  it("reports a coercion but stays quiet on a supported value", () => {
+    const { logger, warnings } = recorder();
+    normalizeInjectionType("HAWKEYE", logger);
+    normalizeInjectionType("NONE", logger);
+    assert.equal(warnings.length, 0);
+
+    normalizeInjectionType("CDP", logger);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /CDP/);
+    assert.match(warnings[0], /HAWKEYE/);
+  });
+
+  it("works without a logger", () => {
+    assert.doesNotThrow(() => normalizeInjectionType("MSWJS"));
+  });
+});
+
+describe("normalizeRedactionHash", () => {
+  it("passes through the one supported OPRF mode", () => {
+    assert.equal(normalizeRedactionHash("oprf-raw"), "oprf-raw");
+    assert.equal(SUPPORTED_REDACTION_HASH, "oprf-raw");
+  });
+
+  it("coerces the other modes the attestor schema allows", () => {
+    // Schema enum is oprf | oprf-mpc | oprf-raw.
+    assert.equal(normalizeRedactionHash("oprf"), "oprf-raw");
+    assert.equal(normalizeRedactionHash("oprf-mpc"), "oprf-raw");
+    assert.equal(normalizeRedactionHash("something-else"), "oprf-raw");
+  });
+
+  it("leaves an absent hash absent — that is not hashing", () => {
+    // Real provider documents carry `hash: null` on non-hashed redactions.
+    // Coercing those would hash a value the provider meant to reveal.
+    for (const nothing of [null, undefined, "", false, 0]) {
+      assert.equal(normalizeRedactionHash(nothing), undefined, JSON.stringify(nothing));
+    }
+  });
+
+  it("reports a coercion but stays quiet on oprf-raw and on no hash", () => {
+    const { logger, warnings } = recorder();
+    normalizeRedactionHash("oprf-raw", logger);
+    normalizeRedactionHash(null, logger);
+    assert.equal(warnings.length, 0);
+
+    normalizeRedactionHash("oprf-mpc", logger);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /oprf-mpc/);
+    assert.match(warnings[0], /oprf-raw/);
+  });
+});

--- a/src/utils/session-timer.js
+++ b/src/utils/session-timer.js
@@ -4,17 +4,21 @@
  */
 
 import { SESSION_TIMER_DURATION_MS } from "./constants/config";
+// Safe to import directly: background.js is the only importer of this module, so
+// this cannot start the hub in a consumer page. These lines used to be bare
+// console.log — the one part of the flow visible locally and unqueryable
+// remotely, ignoring both consoleEnabled and logLevel.
+import { loggingHub } from "./logger/LoggingHub";
+import { EVENT_TYPES } from "./logger/constants";
 
 export class SessionTimerManager {
   constructor() {
-    // Timer for session
     this.sessionTimer = null;
     this.sessionTimerDuration = SESSION_TIMER_DURATION_MS;
     this.sessionTimerPaused = false;
     this.sessionTimerRemainingTime = 0;
     this.sessionTimerStartTime = 0;
 
-    // Callback for session timeout
     this.onSessionTimeout = null;
   }
 
@@ -30,20 +34,23 @@ export class SessionTimerManager {
    * Start session timer (default 30 seconds)
    */
   startSessionTimer() {
-    console.log("[SESSION TIMER] Starting session timer");
-    // Clear any existing timer
+    loggingHub.debug("[SESSION TIMER] Starting session timer", "background.session");
     this.clearSessionTimer();
 
     this.sessionTimerStartTime = Date.now();
     this.sessionTimer = setTimeout(() => {
-      // Check if timer is still valid before firing timeout
       if (this.sessionTimer !== null) {
-        console.error("[SESSION TIMER] Session timer expired");
+        loggingHub.error("[SESSION TIMER] Session timer expired", "background.session", {
+          eventType: EVENT_TYPES.CLAIM_CREATION_TIMED_OUT_EXCEPTION,
+        });
         if (this.onSessionTimeout) {
           this.onSessionTimeout("Session timeout: No proofs generated within time limit");
         }
       } else {
-        console.log("[SESSION TIMER] Timer was already cleared, ignoring timeout");
+        loggingHub.debug(
+          "[SESSION TIMER] Timer was already cleared, ignoring timeout",
+          "background.session",
+        );
       }
     }, this.sessionTimerDuration);
   }
@@ -52,7 +59,7 @@ export class SessionTimerManager {
    * Reset session timer (called after successful proof generation)
    */
   resetSessionTimer() {
-    console.log("[SESSION TIMER] Resetting session timer");
+    loggingHub.debug("[SESSION TIMER] Resetting session timer", "background.session");
     this.clearSessionTimer();
     this.startSessionTimer();
   }
@@ -72,12 +79,11 @@ export class SessionTimerManager {
    */
   pauseSessionTimer() {
     if (this.sessionTimer && !this.sessionTimerPaused) {
-      console.log("[SESSION TIMER] Pausing session timer");
+      loggingHub.debug("[SESSION TIMER] Pausing session timer", "background.session");
       // Calculate remaining time
       const elapsedTime = Date.now() - this.sessionTimerStartTime;
       this.sessionTimerRemainingTime = Math.max(0, this.sessionTimerDuration - elapsedTime);
 
-      // Clear the current timer
       this.clearSessionTimer();
       this.sessionTimerPaused = true;
     }
@@ -88,13 +94,15 @@ export class SessionTimerManager {
    */
   resumeSessionTimer() {
     if (this.sessionTimerPaused) {
-      console.log(
-        "[SESSION TIMER] Resuming session timer with remaining time:",
-        this.sessionTimerRemainingTime,
+      loggingHub.debug(
+        `[SESSION TIMER] Resuming session timer with ${this.sessionTimerRemainingTime}ms remaining`,
+        "background.session",
       );
 
       this.sessionTimer = setTimeout(() => {
-        console.error("[SESSION TIMER] Session timer expired");
+        loggingHub.error("[SESSION TIMER] Session timer expired", "background.session", {
+          eventType: EVENT_TYPES.CLAIM_CREATION_TIMED_OUT_EXCEPTION,
+        });
         if (this.onSessionTimeout) {
           this.onSessionTimeout("Session timeout: No proofs generated within time limit");
         }
@@ -110,7 +118,7 @@ export class SessionTimerManager {
    * Clear all timers
    */
   clearAllTimers() {
-    console.log("[SESSION TIMER] Clearing all timers");
+    loggingHub.debug("[SESSION TIMER] Clearing all timers", "background.session");
     this.clearSessionTimer();
     this.sessionTimerPaused = false;
     this.sessionTimerRemainingTime = 0;

--- a/src/utils/websocket-polyfill.js
+++ b/src/utils/websocket-polyfill.js
@@ -20,7 +20,6 @@ if (!isBackgroundContext) {
     constructor(url, protocols) {
       super(url, protocols);
 
-      // Add event handling compatibility
       this.addEventListener("error", (event) => {
         if (typeof this.onerror === "function") {
           this.onerror(event);
@@ -46,7 +45,6 @@ if (!isBackgroundContext) {
       });
     }
 
-    // Add a promise-based send method expected by some libraries
     sendPromise(data) {
       return new Promise((resolve, reject) => {
         try {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,7 +103,11 @@ const commonResolve = {
   },
 };
 
-const DROP_CONSOLE = process.env.DROP_CONSOLE === "false";
+// Opt-in only, and note the polarity: this used to be `=== "false"`, so setting
+// DROP_CONSOLE=false *enabled* console stripping and there was no way to ask for
+// it by name. Consoles are the SDK's local debugging surface (see
+// DEFAULT_LOG_CONFIG.consoleEnabled), so stripping them must be deliberate.
+const DROP_CONSOLE = process.env.DROP_CONSOLE === "true";
 
 const commonOptimization = {
   minimize: true,


### PR DESCRIPTION
attestor-core 5.0.5 -> 5.1.1 (pinned). 5.1.1 restores the ./browser bundle that 5.1.0 dropped and re-registers the stwo ZK operator that 5.0.6-5.0.8 lost, and ships lib/ as ESM — so attestor-parity.test.js now runs instead of skipping, differentially checking the vendored extraction code against the real attestor. Fixes "oprf-raw cross-block markers incomplete".

Logging
- One log level governs console and endpoint, and decides redaction: INFO redacts, FINE ships raw. Removes remoteLogLevel and the destination-based split that published claimData.context.extractedParameters — the plaintext value being proven — to Loki on every successful session.
- Level names match the platform (SEVERE/WARNING/INFO/FINE) so extension sessions are filterable alongside the InApp SDK's.
- claimData, extractedParameters, injectionResult and rdObject are opaque at INFO; user-data keys are blanked whatever their type.

Diagnostics
- describeRequestMatch reports which check rejected a request; the content script logs near misses and a per-matcher timeout summary, which finally gives RECLAIM_VERIFICATION_NO_ACTIVITY_DETECTED_EXCEPTION a trigger.
- Extraction now logs success per selector, not only failure.
- SessionTimerManager logs through the hub instead of bare console.log.

Fixes
- PROOF_RESPONSE_TIMEOUT_MS (60s) was shorter than PROOF_GENERATION_TIMEOUT_MS (120s), so the outer timeout always won and killed proofs still in progress. Now derived as inner + 15s.
- Proof timeouts rejected a plain object, so the failure logged as "Proof generation failed: undefined" and that reached the consumer.
- The popup's claim counter lived in the content script, which is rebuilt on every navigation, so a 3-claim multi-origin session showed 1/1. The background now owns the counts.

Tests: 173, none skipped. Adds example-provider.test.js, which walks the published `example` provider's three requests through matching and extraction against values a real session produced.